### PR TITLE
Prepare for 1.0.0-alpha.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "value-bag"
-version = "0.1.0"
+version = "1.0.0-alpha.1"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"
@@ -52,9 +52,6 @@ optional = true
 # Only needed on non-nightly compilers
 [dependencies.ctor]
 version = "0.1"
-
-[build-dependencies]
-version_check = "0.9"
 
 [dev-dependencies.sval]
 version = "1.0.0-alpha.3"

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,30 @@
-extern crate version_check as rustc;
+use std::{
+    str,
+    env,
+    process::Command,
+};
 
 fn main() {
-    if rustc::is_feature_flaggable().unwrap_or(false) {
+    if rustc_is_nightly().unwrap_or(false) {
         println!("cargo:rustc-cfg=value_bag_const_type_id");
     }
+}
+
+fn rustc_is_nightly() -> Option<bool> {
+    let rustc = match env::var_os("RUSTC") {
+        Some(rustc) => rustc,
+        None => return None,
+    };
+
+    let output = match Command::new(rustc).arg("--version").output() {
+        Ok(output) => output,
+        Err(_) => return None,
+    };
+
+    let version = match str::from_utf8(&output.stdout) {
+        Ok(version) => version,
+        Err(_) => return None,
+    };
+
+    Some(version.contains("-nightly"))
 }


### PR DESCRIPTION
Also removes the `version_check` dependency.