### PR TITLE
Make fill and test modules public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,10 @@ build = "build.rs"
 features = ["std", "sval", "serde"]
 
 [features]
+# Use the standard library
 std = []
+
+# Add support for `serde`
 serde = [
     "serde_lib",
     "sval/serde1",
@@ -27,6 +30,9 @@ serde = [
     "erased-serde/alloc",
     "serde_fmt"
 ]
+
+# Add support for converting value bags into test tokens
+test = []
 
 [dependencies.sval]
 version = "1.0.0-alpha.3"

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,4 @@
-use std::{
-    str,
-    env,
-    process::Command,
-};
+use std::{env, process::Command, str};
 
 fn main() {
     if rustc_is_nightly().unwrap_or(false) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,7 +44,7 @@ impl From<fmt::Error> for Error {
 #[cfg(feature = "std")]
 mod std_support {
     use super::*;
-    use crate::std::{error, io, boxed::Box};
+    use crate::std::{boxed::Box, error, io};
 
     pub(super) type BoxedError = Box<dyn error::Error + Send + Sync>;
 

--- a/src/fill.rs
+++ b/src/fill.rs
@@ -1,4 +1,4 @@
-//! Lazy value initialization.
+//! Deferred value initialization.
 
 use crate::std::fmt;
 

--- a/src/internal/cast/mod.rs
+++ b/src/internal/cast/mod.rs
@@ -405,10 +405,7 @@ mod std_support {
 
     #[cfg(test)]
     mod tests {
-        use crate::{
-            test::IntoValueBag,
-            std::borrow::ToOwned,
-        };
+        use crate::{std::borrow::ToOwned, test::IntoValueBag};
 
         #[test]
         fn primitive_cast() {

--- a/src/internal/cast/primitive.rs
+++ b/src/internal/cast/primitive.rs
@@ -31,7 +31,7 @@ pub(super) fn from_any<'v, T: 'static>(value: &'v T) -> Option<Primitive<'v>> {
                             const $const_ident: TypeId = TypeId::of::<$ty>();
                             const $option_ident: TypeId = TypeId::of::<Option<$ty>>();
                         );*
-    
+
                         match TypeId::of::<Self>() {
                             $(
                                 $const_ident => |v| Some(Primitive::from(unsafe { *(v as *const Self as *const $ty) })),
@@ -43,20 +43,20 @@ pub(super) fn from_any<'v, T: 'static>(value: &'v T) -> Option<Primitive<'v>> {
                                     }
                                 }),
                             )*
-    
+
                             _ => |_| None,
                         }
                     };
-    
+
                     fn to_primitive(&self) -> Option<Primitive> {
                         (Self::CALL)(self)
                     }
                 }
-    
+
                 impl<T: ?Sized + 'static> ToPrimitive for T {}
             }
         }
-    
+
         // NOTE: The types here *must* match the ones used below when `const_type_id` is not available
         to_primitive![
             usize: (USIZE, OPTION_USIZE),
@@ -64,21 +64,21 @@ pub(super) fn from_any<'v, T: 'static>(value: &'v T) -> Option<Primitive<'v>> {
             u16: (U16, OPTION_U16),
             u32: (U32, OPTION_U32),
             u64: (U64, OPTION_U64),
-    
+
             isize: (ISIZE, OPTION_ISIZE),
             i8: (I8, OPTION_I8),
             i16: (I16, OPTION_I16),
             i32: (I32, OPTION_I32),
             i64: (I64, OPTION_I64),
-    
+
             f32: (F32, OPTION_F32),
             f64: (F64, OPTION_F64),
-    
+
             char: (CHAR, OPTION_CHAR),
             bool: (BOOL, OPTION_BOOL),
             &'static str: (STR, OPTION_STR),
         ];
-    
+
         value.to_primitive()
     }
 
@@ -95,10 +95,7 @@ pub(super) fn from_any<'v, T: 'static>(value: &'v T) -> Option<Primitive<'v>> {
         use ctor::ctor;
 
         use crate::std::{
-            any::{
-                Any,
-                TypeId,
-            },
+            any::{Any, TypeId},
             cmp::Ordering,
         };
 
@@ -141,9 +138,11 @@ pub(super) fn from_any<'v, T: 'static>(value: &'v T) -> Option<Primitive<'v>> {
         // We use this algorithm instead of the standard library's `sort_by` because it
         // works in no-std environments
         fn quicksort_helper<T, F>(arr: &mut [T], left: isize, right: isize, compare: &F)
-        where F: Fn(&T, &T) -> Ordering {
+        where
+            F: Fn(&T, &T) -> Ordering,
+        {
             if right <= left {
-                return
+                return;
             }
 
             let mut i: isize = left - 1;
@@ -160,12 +159,12 @@ pub(super) fn from_any<'v, T: 'static>(value: &'v T) -> Option<Primitive<'v>> {
                     j -= 1;
                     while compare(&*v, &arr[j as usize]) == Ordering::Less {
                         if j == left {
-                            break
+                            break;
                         }
                         j -= 1;
                     }
                     if i >= j {
-                        break
+                        break;
                     }
                     arr.swap(i as usize, j as usize);
                     if compare(&arr[i as usize], &*v) == Ordering::Equal {
@@ -201,9 +200,12 @@ pub(super) fn from_any<'v, T: 'static>(value: &'v T) -> Option<Primitive<'v>> {
             quicksort_helper(arr, i, right, compare);
         }
 
-        fn quicksort_by<T, F>(arr: &mut [T], compare: F) where F: Fn(&T, &T) -> Ordering {
+        fn quicksort_by<T, F>(arr: &mut [T], compare: F)
+        where
+            F: Fn(&T, &T) -> Ordering,
+        {
             if arr.len() <= 1 {
-                return
+                return;
             }
 
             let len = arr.len();
@@ -211,7 +213,10 @@ pub(super) fn from_any<'v, T: 'static>(value: &'v T) -> Option<Primitive<'v>> {
         }
 
         #[ctor]
-        static TYPE_IDS: [(TypeId, for<'a> fn(&'a (dyn std::any::Any + 'static)) -> Primitive<'a>); 30] = {
+        static TYPE_IDS: [(
+            TypeId,
+            for<'a> fn(&'a (dyn std::any::Any + 'static)) -> Primitive<'a>,
+        ); 30] = {
             // NOTE: The types here *must* match the ones used above when `const_type_id` is available
             let mut type_ids = type_ids![
                 usize,

--- a/src/internal/error.rs
+++ b/src/internal/error.rs
@@ -1,6 +1,7 @@
 use crate::{
+    fill::Slot,
     std::{error, fmt},
-    Slot, ValueBag,
+    ValueBag,
 };
 
 use super::{cast, Inner};
@@ -83,10 +84,7 @@ impl<'v> From<&'v (dyn error::Error)> for ValueBag<'v> {
 mod tests {
     use super::*;
 
-    use crate::std::{
-        io,
-        string::ToString,
-    };
+    use crate::std::{io, string::ToString};
 
     #[test]
     fn error_capture() {

--- a/src/internal/fmt.rs
+++ b/src/internal/fmt.rs
@@ -3,7 +3,7 @@
 //! This module allows any `Value` to implement the `Debug` and `Display` traits,
 //! and for any `Debug` or `Display` to be captured as a `Value`.
 
-use crate::{std::fmt, Error, Slot, ValueBag};
+use crate::{fill::Slot, std::fmt, Error, ValueBag};
 
 use super::{cast, Inner, Visitor};
 

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -3,9 +3,11 @@
 //! This implementation isn't intended to be public. It may need to change
 //! for optimizations or to support new external serialization frameworks.
 
-use crate::std::any::TypeId;
-
-use super::{Error, Fill, Slot};
+use crate::{
+    fill::{Fill, Slot},
+    std::any::TypeId,
+    Error,
+};
 
 pub(super) mod cast;
 #[cfg(feature = "std")]

--- a/src/internal/serde.rs
+++ b/src/internal/serde.rs
@@ -1,6 +1,7 @@
 use crate::{
+    fill::Slot,
     std::{fmt, marker::PhantomData},
-    Error, Slot, ValueBag,
+    Error, ValueBag,
 };
 
 use super::{

--- a/src/internal/sval.rs
+++ b/src/internal/sval.rs
@@ -3,7 +3,7 @@
 //! This module allows any `Value` to implement the `Value` trait,
 //! and for any `Value` to be captured as a `Value`.
 
-use crate::{std::fmt, Error, Slot, ValueBag};
+use crate::{fill::Slot, std::fmt, Error, ValueBag};
 
 use super::{
     cast::{self, Cast},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 //! Structured values.
 
 #![cfg_attr(value_bag_const_type_id, feature(const_type_id))]
-
 #![no_std]
 
 #[cfg(any(feature = "std", test))]
@@ -15,17 +14,14 @@ extern crate std;
 extern crate core as std;
 
 mod error;
-mod fill;
+pub mod fill;
 mod impls;
 mod internal;
 
-#[cfg(test)]
-mod test;
+#[cfg(any(test, feature = "test"))]
+pub mod test;
 
-pub use self::{
-    error::Error,
-    fill::{Fill, Slot},
-};
+pub use self::error::Error;
 
 use self::internal::{Inner, Primitive, Visitor};
 
@@ -79,7 +75,7 @@ use self::internal::{Inner, Primitive, Visitor};
 /// compatible with other constructor methods.
 ///
 /// ```
-/// use value_bag::{ValueBag, Slot, Fill, Error};
+/// use value_bag::{ValueBag, Error, fill::{Slot, Fill}};
 ///
 /// struct FillSigned;
 ///
@@ -96,7 +92,7 @@ use self::internal::{Inner, Primitive, Visitor};
 ///
 /// ```
 /// # use std::fmt::Debug;
-/// use value_bag::{ValueBag, Slot, Fill, Error};
+/// use value_bag::{ValueBag, Error, fill::{Slot, Fill}};
 ///
 /// struct FillDebug;
 ///

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,4 @@
-// Test support for inspecting values
+//* Test support for inspecting values.
 
 use crate::std::{fmt, str, string::String};
 
@@ -18,8 +18,12 @@ where
     }
 }
 
+/**
+A tokenized representation of the captured value.
+*/
 #[derive(Debug, PartialEq)]
-pub(crate) enum Token {
+#[non_exhaustive]
+pub enum Token {
     U64(u64),
     I64(i64),
     F64(f64),
@@ -38,9 +42,14 @@ pub(crate) enum Token {
     Serde,
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test"))]
 impl<'v> ValueBag<'v> {
-    pub(crate) fn to_token(&self) -> Token {
+    /**
+    Convert the value bag into a token for testing.
+
+    This _isn't_ a general-purpose API for working with values outside of testing.
+    */
+    pub fn to_token(&self) -> Token {
         struct TestVisitor(Option<Token>);
 
         impl<'v> internal::Visitor<'v> for TestVisitor {

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,4 @@
-//* Test support for inspecting values.
+//! Test support for inspecting values.
 
 use crate::std::{fmt, str, string::String};
 


### PR DESCRIPTION
This is a breaking change that doesn't re-export the fill API from the crate root. Instead, it lives under the `fill` module.