### PR TITLE
Version the serde and sval support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,13 +54,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features sval
+          args: --features sval1
 
       - name: With serde
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features serde
+          args: --features serde1
 
   embedded:
     name: Build (embedded)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,46 +22,58 @@ features = ["std", "sval", "serde"]
 # Use the standard library
 std = []
 
+# Add support for sval
+sval = ["sval1"]
+
+sval1 = ["sval1_lib"]
+
 # Add support for `serde`
-serde = [
-    "serde_lib",
-    "sval/serde1",
-    "sval/alloc",
-    "erased-serde/alloc",
-    "serde_fmt"
+serde = ["serde1"]
+
+serde1 = [
+    "serde1_lib",
+    "sval1_lib/serde1",
+    "sval1_lib/alloc",
+    "erased-serde1/alloc",
+    "serde1_fmt"
 ]
 
 # Add support for converting value bags into test tokens
 test = []
 
-[dependencies.sval]
+[dependencies.sval1_lib]
 version = "1.0.0-alpha.3"
 optional = true
 default-features = false
 features = ["fmt"]
+package = "sval"
 
-[dependencies.serde_lib]
+[dependencies.serde1_lib]
 version = "1"
 default-features = false
 optional = true
 package = "serde"
 
-[dependencies.serde_fmt]
+[dependencies.serde1_fmt]
 version = "1"
 optional = true
+package = "serde_fmt"
 
-[dependencies.erased-serde]
+[dependencies.erased-serde1]
 version = "0.3"
 default-features = false
 optional = true
+package = "erased-serde"
 
 # Only needed on non-nightly compilers
 [dependencies.ctor]
 version = "0.1"
 
-[dev-dependencies.sval]
+[dev-dependencies.sval1_lib]
 version = "1.0.0-alpha.3"
 features = ["test"]
+package = "sval"
 
-[dev-dependencies.serde_test]
+[dev-dependencies.serde1_test]
 version = "1"
+package = "serde_test"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,60 @@
 # `value-bag`
+
 [![Rust](https://github.com/sval-rs/value-bag/workflows/Rust/badge.svg)](https://github.com/sval-rs/value-bag/actions)
 [![Latest version](https://img.shields.io/crates/v/value-bag.svg)](https://crates.io/crates/value-bag)
 [![Documentation Latest](https://docs.rs/value-bag/badge.svg)](https://docs.rs/value-bag)
+
+## Getting started
+
+Add the `value-bag` crate to your `Cargo.toml`:
+
+```rust
+[dependencies.value-bag]
+version = "1.0.0-alpha.1"
+```
+
+You'll probably also want to add a feature for either `sval` (if you're in a no-std environment) or `serde` (if you need to integrate with other code that uses `serde`):
+
+```rust
+[dependencies.value-bag]
+version = "1.0.0-alpha.1"
+features = ["sval1"]
+```
+
+```rust
+[dependencies.value-bag]
+version = "1.0.0-alpha.1"
+features = ["serde1"]
+```
+
+Then you're ready to capture anonymous values!
+
+```rust
+#[derive(Serialize)]
+struct MyValue {
+    title: String,
+    description: String,
+    version: u32,
+}
+
+// Capture a value that implements `serde::Serialize`
+let bag = ValueBag::capture_serde1(&my_value);
+
+// Print the contents of the value bag
+println!("{:?}", bag);
+```
+
+## Cargo features
+
+The `value-bag` crate is no-std by default, and offers the following Cargo features:
+
+- `std`: Enable support for the standard library. This allows more types to be captured in a `ValueBag`.
+- `sval`: Enable support for using the [`sval`](https://github.com/sval-rs/sval) serialization framework for inspecting `ValueBag`s by implementing `sval::value::Value`. Implies `sval1`.
+    - `sval1`: Enable support for the stable `1.x.x` version of `sval`.
+- `serde`: Enable support for using the [`serde`](https://github.com/serde-rs/serde) serialization framework for inspecting `ValueBag`s by implementing `serde::Serialize`. Implies `std` and `serde1`.
+    - `serde1`: Enable support for the stable `1.x.x` version of `serde`.
+
+## What is a value bag?
 
 A `ValueBag` is an anonymous structured bag that supports casting, downcasting, formatting, and serializing. The goal of a `ValueBag` is to decouple the producers of structured data from its consumers. A `ValueBag` can _always_ be interrogated using the consumers serialization API of choice, even if that wasn't the one the producer used to capture the data in the first place.
 
@@ -41,7 +94,7 @@ let work = Work {
     description: String::from("do the work"),
 }
 
-let bag = ValueBag::capture_sval(&work);
+let bag = ValueBag::capture_sval1(&work);
 ```
 
 It could then be formatted using `Display`, even though `Work` never implemented that trait:

--- a/src/internal/cast/mod.rs
+++ b/src/internal/cast/mod.rs
@@ -207,13 +207,13 @@ impl<'v> ValueBag<'v> {
                 type_id: Some(type_id),
                 value,
             } if type_id == target => Some(unsafe { &*(value as *const _ as *const T) }),
-            #[cfg(feature = "sval")]
-            Inner::Sval {
+            #[cfg(feature = "sval1")]
+            Inner::Sval1 {
                 type_id: Some(type_id),
                 value,
             } if type_id == target => Some(unsafe { &*(value as *const _ as *const T) }),
-            #[cfg(feature = "serde")]
-            Inner::Serde {
+            #[cfg(feature = "serde1")]
+            Inner::Serde1 {
                 type_id: Some(type_id),
                 value,
             } if type_id == target => Some(unsafe { &*(value as *const _ as *const T) }),
@@ -283,15 +283,15 @@ impl<'v> Inner<'v> {
                 Ok(())
             }
 
-            #[cfg(feature = "sval")]
-            fn sval(&mut self, v: &dyn super::sval::Value) -> Result<(), Error> {
-                self.0 = super::sval::cast(v);
+            #[cfg(feature = "sval1")]
+            fn sval1(&mut self, v: &dyn super::sval::v1::Value) -> Result<(), Error> {
+                self.0 = super::sval::v1::cast(v);
                 Ok(())
             }
 
-            #[cfg(feature = "serde")]
-            fn serde(&mut self, v: &dyn super::serde::Serialize) -> Result<(), Error> {
-                self.0 = super::serde::cast(v);
+            #[cfg(feature = "serde1")]
+            fn serde1(&mut self, v: &dyn super::serde::v1::Serialize) -> Result<(), Error> {
+                self.0 = super::serde::v1::cast(v);
                 Ok(())
             }
         }
@@ -307,7 +307,7 @@ impl<'v> Inner<'v> {
     }
 }
 
-pub(super) enum Cast<'v> {
+pub(in crate::internal) enum Cast<'v> {
     Primitive(Primitive<'v>),
     #[cfg(feature = "std")]
     String(String),

--- a/src/internal/fmt.rs
+++ b/src/internal/fmt.rs
@@ -137,14 +137,17 @@ impl<'v> Debug for ValueBag<'v> {
                 Ok(())
             }
 
-            #[cfg(feature = "sval")]
-            fn sval(&mut self, v: &dyn super::sval::Value) -> Result<(), Error> {
-                super::sval::fmt(self.0, v)
+            #[cfg(feature = "sval1")]
+            fn sval1(&mut self, v: &dyn crate::internal::sval::v1::Value) -> Result<(), Error> {
+                crate::internal::sval::v1::fmt(self.0, v)
             }
 
-            #[cfg(feature = "serde")]
-            fn serde(&mut self, v: &dyn super::serde::Serialize) -> Result<(), Error> {
-                super::serde::fmt(self.0, v)
+            #[cfg(feature = "serde1")]
+            fn serde1(
+                &mut self,
+                v: &dyn crate::internal::serde::v1::Serialize,
+            ) -> Result<(), Error> {
+                crate::internal::serde::v1::fmt(self.0, v)
             }
         }
 
@@ -218,14 +221,17 @@ impl<'v> Display for ValueBag<'v> {
                 Ok(())
             }
 
-            #[cfg(feature = "sval")]
-            fn sval(&mut self, v: &dyn super::sval::Value) -> Result<(), Error> {
-                super::sval::fmt(self.0, v)
+            #[cfg(feature = "sval1")]
+            fn sval1(&mut self, v: &dyn crate::internal::sval::v1::Value) -> Result<(), Error> {
+                crate::internal::sval::v1::fmt(self.0, v)
             }
 
-            #[cfg(feature = "serde")]
-            fn serde(&mut self, v: &dyn super::serde::Serialize) -> Result<(), Error> {
-                super::serde::fmt(self.0, v)
+            #[cfg(feature = "serde1")]
+            fn serde1(
+                &mut self,
+                v: &dyn crate::internal::serde::v1::Serialize,
+            ) -> Result<(), Error> {
+                crate::internal::serde::v1::fmt(self.0, v)
             }
         }
 

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -13,9 +13,9 @@ pub(super) mod cast;
 #[cfg(feature = "std")]
 pub(super) mod error;
 pub(super) mod fmt;
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde1")]
 pub(super) mod serde;
-#[cfg(feature = "sval")]
+#[cfg(feature = "sval1")]
 pub(super) mod sval;
 
 /// A container for a structured value for a specific kind of visitor.
@@ -43,17 +43,17 @@ pub(super) enum Inner<'v> {
         type_id: Option<TypeId>,
     },
 
-    #[cfg(feature = "sval")]
+    #[cfg(feature = "sval1")]
     /// A structured value from `sval`.
-    Sval {
-        value: &'v dyn sval::Value,
+    Sval1 {
+        value: &'v dyn sval::v1::Value,
         type_id: Option<TypeId>,
     },
 
-    #[cfg(feature = "serde")]
+    #[cfg(feature = "serde1")]
     /// A structured value from `serde`.
-    Serde {
-        value: &'v dyn serde::Serialize,
+    Serde1 {
+        value: &'v dyn serde::v1::Serialize,
         type_id: Option<TypeId>,
     },
 }
@@ -70,11 +70,11 @@ impl<'v> Inner<'v> {
             #[cfg(feature = "std")]
             Inner::Error { value, .. } => visitor.error(value),
 
-            #[cfg(feature = "sval")]
-            Inner::Sval { value, .. } => visitor.sval(value),
+            #[cfg(feature = "sval1")]
+            Inner::Sval1 { value, .. } => visitor.sval1(value),
 
-            #[cfg(feature = "serde")]
-            Inner::Serde { value, .. } => visitor.serde(value),
+            #[cfg(feature = "serde1")]
+            Inner::Serde1 { value, .. } => visitor.serde1(value),
         }
     }
 }
@@ -102,11 +102,11 @@ pub(super) trait Visitor<'v> {
     #[cfg(feature = "std")]
     fn error(&mut self, v: &dyn error::Error) -> Result<(), Error>;
 
-    #[cfg(feature = "sval")]
-    fn sval(&mut self, v: &dyn sval::Value) -> Result<(), Error>;
+    #[cfg(feature = "sval1")]
+    fn sval1(&mut self, v: &dyn sval::v1::Value) -> Result<(), Error>;
 
-    #[cfg(feature = "serde")]
-    fn serde(&mut self, v: &dyn serde::Serialize) -> Result<(), Error>;
+    #[cfg(feature = "serde1")]
+    fn serde1(&mut self, v: &dyn serde::v1::Serialize) -> Result<(), Error>;
 }
 
 /// A captured primitive value.

--- a/src/internal/serde/mod.rs
+++ b/src/internal/serde/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod v1;

--- a/src/internal/sval/mod.rs
+++ b/src/internal/sval/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod v1;

--- a/src/test.rs
+++ b/src/test.rs
@@ -35,11 +35,23 @@ pub enum Token {
     #[cfg(feature = "std")]
     Error,
 
-    #[cfg(feature = "sval")]
-    Sval,
+    #[cfg(feature = "sval1")]
+    Sval(Sval),
 
-    #[cfg(feature = "serde")]
-    Serde,
+    #[cfg(feature = "serde1")]
+    Serde(Serde),
+}
+
+#[derive(Debug, PartialEq)]
+#[non_exhaustive]
+pub struct Sval {
+    pub version: u32,
+}
+
+#[derive(Debug, PartialEq)]
+#[non_exhaustive]
+pub struct Serde {
+    pub version: u32,
 }
 
 #[cfg(any(test, feature = "test"))]
@@ -99,15 +111,15 @@ impl<'v> ValueBag<'v> {
                 Ok(())
             }
 
-            #[cfg(feature = "sval")]
-            fn sval(&mut self, _: &dyn internal::sval::Value) -> Result<(), Error> {
-                self.0 = Some(Token::Sval);
+            #[cfg(feature = "sval1")]
+            fn sval1(&mut self, _: &dyn internal::sval::v1::Value) -> Result<(), Error> {
+                self.0 = Some(Token::Sval(Sval { version: 1 }));
                 Ok(())
             }
 
-            #[cfg(feature = "serde")]
-            fn serde(&mut self, _: &dyn internal::serde::Serialize) -> Result<(), Error> {
-                self.0 = Some(Token::Serde);
+            #[cfg(feature = "serde1")]
+            fn serde1(&mut self, _: &dyn internal::serde::v1::Serialize) -> Result<(), Error> {
+                self.0 = Some(Token::Serde(Serde { version: 1 }));
                 Ok(())
             }
         }


### PR DESCRIPTION
This uses the same strategy as `sval` to version external public dependencies.