### PR TITLE
Fix the test feature when not compiled with std

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,6 +43,11 @@ jobs:
         with:
           command: test
           args: --all-features
+      
+      - name: With test
+        uses: actions-rs/cargo@v1
+        with:
+          command: check --features test
 
       - name: With std
         uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,8 @@ jobs:
       - name: With test
         uses: actions-rs/cargo@v1
         with:
-          command: check --features test
+          command: check
+          args: --features test
 
       - name: With std
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ serde1 = [
 ]
 
 # Add support for converting value bags into test tokens
-test = []
+test = ["std"]
 
 [dependencies.sval1_lib]
 version = "1.0.0-alpha.3"

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The `value-bag` crate is no-std by default, and offers the following Cargo featu
     - `sval1`: Enable support for the stable `1.x.x` version of `sval`.
 - `serde`: Enable support for using the [`serde`](https://github.com/serde-rs/serde) serialization framework for inspecting `ValueBag`s by implementing `serde::Serialize`. Implies `std` and `serde1`.
     - `serde1`: Enable support for the stable `1.x.x` version of `serde`.
+- `test`: Add test helpers for inspecting the shape of the value inside a `ValueBag`.
 
 ## What is a value bag?
 


### PR DESCRIPTION
The `test` feature shipped in `1.0.0-alpha.2` is actually broken. This PR fixes it up by also requiring the `std` feature implicitly.