### PR TITLE
Always use &dyn Error + 'static

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,11 @@ use std::{env, process::Command, str};
 
 fn main() {
     if rustc_is_nightly().unwrap_or(false) {
-        println!("cargo:rustc-cfg=value_bag_const_type_id");
+        println!("cargo:rustc-cfg=value_bag_capture_const_type_id");
+    } else if target_arch_is_any(&["x86_64", "aarch64"]) {
+        println!("cargo:rustc-cfg=value_bag_capture_ctor");
+    } else {
+        println!("cargo:rustc-cfg=value_bag_capture_fallback");
     }
 }
 
@@ -23,4 +27,11 @@ fn rustc_is_nightly() -> Option<bool> {
     };
 
     Some(version.contains("-nightly"))
+}
+
+fn target_arch_is_any(targets: &[&str]) -> bool {
+    match env::var("CARGO_CFG_TARGET_ARCH") {
+        Ok(arch) if targets.contains(&&*arch) => true,
+        _ => false,
+    }
 }

--- a/src/internal/cast/primitive.rs
+++ b/src/internal/cast/primitive.rs
@@ -10,7 +10,7 @@ use crate::internal::Primitive;
 
 pub(super) fn from_any<'v, T: 'static>(value: &'v T) -> Option<Primitive<'v>> {
     // When we're on `nightly`, we can use const type ids
-    #[cfg(value_bag_const_type_id)]
+    #[cfg(value_bag_capture_const_type_id)]
     {
         use crate::std::any::TypeId;
 
@@ -77,183 +77,170 @@ pub(super) fn from_any<'v, T: 'static>(value: &'v T) -> Option<Primitive<'v>> {
     }
 
     // When we're not on `nightly`, use the ctor crate
-    #[cfg(not(value_bag_const_type_id))]
+    #[cfg(value_bag_capture_ctor)]
     {
-        // Specifically shortlisted architectures that seem to support ctor
-        #[cfg(any(
-            target_arch = "x86",
-            target_arch = "x86_64",
-            target_arch = "arm",
-            target_arch = "aarch64"
-        ))]
-        {
-            #![allow(unused_unsafe)]
+        #![allow(unused_unsafe)]
 
-            use ctor::ctor;
+        use ctor::ctor;
 
-            use crate::std::{
-                any::{Any, TypeId},
-                cmp::Ordering,
-            };
+        use crate::std::{
+            any::{Any, TypeId},
+            cmp::Ordering,
+        };
 
-            macro_rules! type_ids {
-                ($($ty:ty,)*) => {
-                    [
-                        $(
-                            (
-                                std::any::TypeId::of::<$ty>(),
-                                (|value| unsafe {
-                                    debug_assert_eq!(value.type_id(), std::any::TypeId::of::<$ty>());
+        macro_rules! type_ids {
+            ($($ty:ty,)*) => {
+                [
+                    $(
+                        (
+                            std::any::TypeId::of::<$ty>(),
+                            (|value| unsafe {
+                                debug_assert_eq!(value.type_id(), std::any::TypeId::of::<$ty>());
 
-                                    // SAFETY: We verify the value is $ty before casting
-                                    let value = *(value as *const dyn std::any::Any as *const $ty);
+                                // SAFETY: We verify the value is $ty before casting
+                                let value = *(value as *const dyn std::any::Any as *const $ty);
+                                Primitive::from(value)
+                            }) as for<'a> fn(&'a (dyn std::any::Any + 'static)) -> Primitive<'a>
+                        ),
+                    )*
+                    $(
+                        (
+                            std::any::TypeId::of::<Option<$ty>>(),
+                            (|value| unsafe {
+                                debug_assert_eq!(value.type_id(), std::any::TypeId::of::<Option<$ty>>());
+
+                                // SAFETY: We verify the value is Option<$ty> before casting
+                                let value = *(value as *const dyn std::any::Any as *const Option<$ty>);
+                                if let Some(value) = value {
                                     Primitive::from(value)
-                                }) as for<'a> fn(&'a (dyn std::any::Any + 'static)) -> Primitive<'a>
-                            ),
-                        )*
-                        $(
-                            (
-                                std::any::TypeId::of::<Option<$ty>>(),
-                                (|value| unsafe {
-                                    debug_assert_eq!(value.type_id(), std::any::TypeId::of::<Option<$ty>>());
+                                } else {
+                                    Primitive::None
+                                }
+                            }) as for<'a> fn(&'a (dyn std::any::Any + 'static)) -> Primitive<'a>
+                        ),
+                    )*
+                ]
+            };
+        }
 
-                                    // SAFETY: We verify the value is Option<$ty> before casting
-                                    let value = *(value as *const dyn std::any::Any as *const Option<$ty>);
-                                    if let Some(value) = value {
-                                        Primitive::from(value)
-                                    } else {
-                                        Primitive::None
-                                    }
-                                }) as for<'a> fn(&'a (dyn std::any::Any + 'static)) -> Primitive<'a>
-                            ),
-                        )*
-                    ]
-                };
+        // From: https://github.com/servo/rust-quicksort
+        // We use this algorithm instead of the standard library's `sort_by` because it
+        // works in no-std environments
+        fn quicksort_helper<T, F>(arr: &mut [T], left: isize, right: isize, compare: &F)
+        where
+            F: Fn(&T, &T) -> Ordering,
+        {
+            if right <= left {
+                return;
             }
 
-            // From: https://github.com/servo/rust-quicksort
-            // We use this algorithm instead of the standard library's `sort_by` because it
-            // works in no-std environments
-            fn quicksort_helper<T, F>(arr: &mut [T], left: isize, right: isize, compare: &F)
-            where
-                F: Fn(&T, &T) -> Ordering,
-            {
-                if right <= left {
-                    return;
-                }
-
-                let mut i: isize = left - 1;
-                let mut j: isize = right;
-                let mut p: isize = i;
-                let mut q: isize = j;
-                unsafe {
-                    let v: *mut T = &mut arr[right as usize];
-                    loop {
-                        i += 1;
-                        while compare(&arr[i as usize], &*v) == Ordering::Less {
-                            i += 1
-                        }
-                        j -= 1;
-                        while compare(&*v, &arr[j as usize]) == Ordering::Less {
-                            if j == left {
-                                break;
-                            }
-                            j -= 1;
-                        }
-                        if i >= j {
+            let mut i: isize = left - 1;
+            let mut j: isize = right;
+            let mut p: isize = i;
+            let mut q: isize = j;
+            unsafe {
+                let v: *mut T = &mut arr[right as usize];
+                loop {
+                    i += 1;
+                    while compare(&arr[i as usize], &*v) == Ordering::Less {
+                        i += 1
+                    }
+                    j -= 1;
+                    while compare(&*v, &arr[j as usize]) == Ordering::Less {
+                        if j == left {
                             break;
                         }
-                        arr.swap(i as usize, j as usize);
-                        if compare(&arr[i as usize], &*v) == Ordering::Equal {
-                            p += 1;
-                            arr.swap(p as usize, i as usize)
-                        }
-                        if compare(&*v, &arr[j as usize]) == Ordering::Equal {
-                            q -= 1;
-                            arr.swap(j as usize, q as usize)
-                        }
+                        j -= 1;
+                    }
+                    if i >= j {
+                        break;
+                    }
+                    arr.swap(i as usize, j as usize);
+                    if compare(&arr[i as usize], &*v) == Ordering::Equal {
+                        p += 1;
+                        arr.swap(p as usize, i as usize)
+                    }
+                    if compare(&*v, &arr[j as usize]) == Ordering::Equal {
+                        q -= 1;
+                        arr.swap(j as usize, q as usize)
                     }
                 }
+            }
 
-                arr.swap(i as usize, right as usize);
-                j = i - 1;
+            arr.swap(i as usize, right as usize);
+            j = i - 1;
+            i += 1;
+            let mut k: isize = left;
+            while k < p {
+                arr.swap(k as usize, j as usize);
+                k += 1;
+                j -= 1;
+                assert!(k < arr.len() as isize);
+            }
+            k = right - 1;
+            while k > q {
+                arr.swap(i as usize, k as usize);
+                k -= 1;
                 i += 1;
-                let mut k: isize = left;
-                while k < p {
-                    arr.swap(k as usize, j as usize);
-                    k += 1;
-                    j -= 1;
-                    assert!(k < arr.len() as isize);
-                }
-                k = right - 1;
-                while k > q {
-                    arr.swap(i as usize, k as usize);
-                    k -= 1;
-                    i += 1;
-                    assert!(k != 0);
-                }
-
-                quicksort_helper(arr, left, j, compare);
-                quicksort_helper(arr, i, right, compare);
+                assert!(k != 0);
             }
 
-            fn quicksort_by<T, F>(arr: &mut [T], compare: F)
-            where
-                F: Fn(&T, &T) -> Ordering,
-            {
-                if arr.len() <= 1 {
-                    return;
-                }
-
-                let len = arr.len();
-                quicksort_helper(arr, 0, (len - 1) as isize, &compare);
-            }
-
-            #[ctor]
-            static TYPE_IDS: [(
-                TypeId,
-                for<'a> fn(&'a (dyn std::any::Any + 'static)) -> Primitive<'a>,
-            ); 30] = {
-                // NOTE: The types here *must* match the ones used above when `const_type_id` is available
-                let mut type_ids = type_ids![
-                    usize,
-                    u8,
-                    u16,
-                    u32,
-                    u64,
-                    isize,
-                    i8,
-                    i16,
-                    i32,
-                    i64,
-                    f32,
-                    f64,
-                    char,
-                    bool,
-                    &'static str,
-                ];
-
-                quicksort_by(&mut type_ids, |&(ref a, _), &(ref b, _)| a.cmp(b));
-
-                type_ids
-            };
-
-            if let Ok(i) = TYPE_IDS.binary_search_by_key(&value.type_id(), |&(k, _)| k) {
-                Some((TYPE_IDS[i].1)(value))
-            } else {
-                None
-            }
+            quicksort_helper(arr, left, j, compare);
+            quicksort_helper(arr, i, right, compare);
         }
 
-        #[cfg(not(any(
-            target_arch = "x86",
-            target_arch = "x86_64",
-            target_arch = "arm",
-            target_arch = "aarch64"
-        )))]
+        fn quicksort_by<T, F>(arr: &mut [T], compare: F)
+        where
+            F: Fn(&T, &T) -> Ordering,
         {
-            let _ = value;
+            if arr.len() <= 1 {
+                return;
+            }
+
+            let len = arr.len();
+            quicksort_helper(arr, 0, (len - 1) as isize, &compare);
+        }
+
+        #[ctor]
+        static TYPE_IDS: [(
+            TypeId,
+            for<'a> fn(&'a (dyn std::any::Any + 'static)) -> Primitive<'a>,
+        ); 30] = {
+            // NOTE: The types here *must* match the ones used above when `const_type_id` is available
+            let mut type_ids = type_ids![
+                usize,
+                u8,
+                u16,
+                u32,
+                u64,
+                isize,
+                i8,
+                i16,
+                i32,
+                i64,
+                f32,
+                f64,
+                char,
+                bool,
+                &'static str,
+            ];
+
+            quicksort_by(&mut type_ids, |&(ref a, _), &(ref b, _)| a.cmp(b));
+
+            type_ids
+        };
+
+        if let Ok(i) = TYPE_IDS.binary_search_by_key(&value.type_id(), |&(k, _)| k) {
+            Some((TYPE_IDS[i].1)(value))
+        } else {
             None
         }
+    }
+
+    // When we're not on `nightly` and aren't on a supported arch, we can't do capturing
+    #[cfg(value_bag_capture_fallback)]
+    {
+        let _ = value;
+        None
     }
 }

--- a/src/internal/cast/primitive.rs
+++ b/src/internal/cast/primitive.rs
@@ -8,14 +8,8 @@ the `'static` bound altogether.
 
 use crate::internal::Primitive;
 
-// Use consts to match a type with a conversion fn
 pub(super) fn from_any<'v, T: 'static>(value: &'v T) -> Option<Primitive<'v>> {
-    /*
-    When the `const_type_id` feature is available, we can use it to determine
-    a function to run at compile-time. It's like an emulated form of specialization.
-
-    This approach is zero-cost at runtime.
-    */
+    // When we're on `nightly`, we can use const type ids
     #[cfg(value_bag_const_type_id)]
     {
         use crate::std::any::TypeId;
@@ -82,168 +76,183 @@ pub(super) fn from_any<'v, T: 'static>(value: &'v T) -> Option<Primitive<'v>> {
         value.to_primitive()
     }
 
-    /*
-    When the `const_type_id` feature is not available, we create a static
-    list of sorted type ids to check through a binary search.
-
-    This approach has a small cost at runtime.
-    */
+    // When we're not on `nightly`, use the ctor crate
     #[cfg(not(value_bag_const_type_id))]
     {
-        #![allow(unused_unsafe)]
-
-        use ctor::ctor;
-
-        use crate::std::{
-            any::{Any, TypeId},
-            cmp::Ordering,
-        };
-
-        macro_rules! type_ids {
-            ($($ty:ty,)*) => {
-                [
-                    $(
-                        (
-                            std::any::TypeId::of::<$ty>(),
-                            (|value| unsafe {
-                                debug_assert_eq!(value.type_id(), std::any::TypeId::of::<$ty>());
-
-                                // SAFETY: We verify the value is $ty before casting
-                                let value = *(value as *const dyn std::any::Any as *const $ty);
-                                Primitive::from(value)
-                            }) as for<'a> fn(&'a (dyn std::any::Any + 'static)) -> Primitive<'a>
-                        ),
-                    )*
-                    $(
-                        (
-                            std::any::TypeId::of::<Option<$ty>>(),
-                            (|value| unsafe {
-                                debug_assert_eq!(value.type_id(), std::any::TypeId::of::<Option<$ty>>());
-
-                                // SAFETY: We verify the value is Option<$ty> before casting
-                                let value = *(value as *const dyn std::any::Any as *const Option<$ty>);
-                                if let Some(value) = value {
-                                    Primitive::from(value)
-                                } else {
-                                    Primitive::None
-                                }
-                            }) as for<'a> fn(&'a (dyn std::any::Any + 'static)) -> Primitive<'a>
-                        ),
-                    )*
-                ]
-            };
-        }
-
-        // From: https://github.com/servo/rust-quicksort
-        // We use this algorithm instead of the standard library's `sort_by` because it
-        // works in no-std environments
-        fn quicksort_helper<T, F>(arr: &mut [T], left: isize, right: isize, compare: &F)
-        where
-            F: Fn(&T, &T) -> Ordering,
+        // Specifically shortlisted architectures that seem to support ctor
+        #[cfg(any(
+            target_arch = "x86",
+            target_arch = "x86_64",
+            target_arch = "arm",
+            target_arch = "aarch64"
+        ))]
         {
-            if right <= left {
-                return;
+            #![allow(unused_unsafe)]
+
+            use ctor::ctor;
+
+            use crate::std::{
+                any::{Any, TypeId},
+                cmp::Ordering,
+            };
+
+            macro_rules! type_ids {
+                ($($ty:ty,)*) => {
+                    [
+                        $(
+                            (
+                                std::any::TypeId::of::<$ty>(),
+                                (|value| unsafe {
+                                    debug_assert_eq!(value.type_id(), std::any::TypeId::of::<$ty>());
+
+                                    // SAFETY: We verify the value is $ty before casting
+                                    let value = *(value as *const dyn std::any::Any as *const $ty);
+                                    Primitive::from(value)
+                                }) as for<'a> fn(&'a (dyn std::any::Any + 'static)) -> Primitive<'a>
+                            ),
+                        )*
+                        $(
+                            (
+                                std::any::TypeId::of::<Option<$ty>>(),
+                                (|value| unsafe {
+                                    debug_assert_eq!(value.type_id(), std::any::TypeId::of::<Option<$ty>>());
+
+                                    // SAFETY: We verify the value is Option<$ty> before casting
+                                    let value = *(value as *const dyn std::any::Any as *const Option<$ty>);
+                                    if let Some(value) = value {
+                                        Primitive::from(value)
+                                    } else {
+                                        Primitive::None
+                                    }
+                                }) as for<'a> fn(&'a (dyn std::any::Any + 'static)) -> Primitive<'a>
+                            ),
+                        )*
+                    ]
+                };
             }
 
-            let mut i: isize = left - 1;
-            let mut j: isize = right;
-            let mut p: isize = i;
-            let mut q: isize = j;
-            unsafe {
-                let v: *mut T = &mut arr[right as usize];
-                loop {
-                    i += 1;
-                    while compare(&arr[i as usize], &*v) == Ordering::Less {
-                        i += 1
-                    }
-                    j -= 1;
-                    while compare(&*v, &arr[j as usize]) == Ordering::Less {
-                        if j == left {
-                            break;
+            // From: https://github.com/servo/rust-quicksort
+            // We use this algorithm instead of the standard library's `sort_by` because it
+            // works in no-std environments
+            fn quicksort_helper<T, F>(arr: &mut [T], left: isize, right: isize, compare: &F)
+            where
+                F: Fn(&T, &T) -> Ordering,
+            {
+                if right <= left {
+                    return;
+                }
+
+                let mut i: isize = left - 1;
+                let mut j: isize = right;
+                let mut p: isize = i;
+                let mut q: isize = j;
+                unsafe {
+                    let v: *mut T = &mut arr[right as usize];
+                    loop {
+                        i += 1;
+                        while compare(&arr[i as usize], &*v) == Ordering::Less {
+                            i += 1
                         }
                         j -= 1;
-                    }
-                    if i >= j {
-                        break;
-                    }
-                    arr.swap(i as usize, j as usize);
-                    if compare(&arr[i as usize], &*v) == Ordering::Equal {
-                        p += 1;
-                        arr.swap(p as usize, i as usize)
-                    }
-                    if compare(&*v, &arr[j as usize]) == Ordering::Equal {
-                        q -= 1;
-                        arr.swap(j as usize, q as usize)
+                        while compare(&*v, &arr[j as usize]) == Ordering::Less {
+                            if j == left {
+                                break;
+                            }
+                            j -= 1;
+                        }
+                        if i >= j {
+                            break;
+                        }
+                        arr.swap(i as usize, j as usize);
+                        if compare(&arr[i as usize], &*v) == Ordering::Equal {
+                            p += 1;
+                            arr.swap(p as usize, i as usize)
+                        }
+                        if compare(&*v, &arr[j as usize]) == Ordering::Equal {
+                            q -= 1;
+                            arr.swap(j as usize, q as usize)
+                        }
                     }
                 }
-            }
 
-            arr.swap(i as usize, right as usize);
-            j = i - 1;
-            i += 1;
-            let mut k: isize = left;
-            while k < p {
-                arr.swap(k as usize, j as usize);
-                k += 1;
-                j -= 1;
-                assert!(k < arr.len() as isize);
-            }
-            k = right - 1;
-            while k > q {
-                arr.swap(i as usize, k as usize);
-                k -= 1;
+                arr.swap(i as usize, right as usize);
+                j = i - 1;
                 i += 1;
-                assert!(k != 0);
+                let mut k: isize = left;
+                while k < p {
+                    arr.swap(k as usize, j as usize);
+                    k += 1;
+                    j -= 1;
+                    assert!(k < arr.len() as isize);
+                }
+                k = right - 1;
+                while k > q {
+                    arr.swap(i as usize, k as usize);
+                    k -= 1;
+                    i += 1;
+                    assert!(k != 0);
+                }
+
+                quicksort_helper(arr, left, j, compare);
+                quicksort_helper(arr, i, right, compare);
             }
 
-            quicksort_helper(arr, left, j, compare);
-            quicksort_helper(arr, i, right, compare);
+            fn quicksort_by<T, F>(arr: &mut [T], compare: F)
+            where
+                F: Fn(&T, &T) -> Ordering,
+            {
+                if arr.len() <= 1 {
+                    return;
+                }
+
+                let len = arr.len();
+                quicksort_helper(arr, 0, (len - 1) as isize, &compare);
+            }
+
+            #[ctor]
+            static TYPE_IDS: [(
+                TypeId,
+                for<'a> fn(&'a (dyn std::any::Any + 'static)) -> Primitive<'a>,
+            ); 30] = {
+                // NOTE: The types here *must* match the ones used above when `const_type_id` is available
+                let mut type_ids = type_ids![
+                    usize,
+                    u8,
+                    u16,
+                    u32,
+                    u64,
+                    isize,
+                    i8,
+                    i16,
+                    i32,
+                    i64,
+                    f32,
+                    f64,
+                    char,
+                    bool,
+                    &'static str,
+                ];
+
+                quicksort_by(&mut type_ids, |&(ref a, _), &(ref b, _)| a.cmp(b));
+
+                type_ids
+            };
+
+            if let Ok(i) = TYPE_IDS.binary_search_by_key(&value.type_id(), |&(k, _)| k) {
+                Some((TYPE_IDS[i].1)(value))
+            } else {
+                None
+            }
         }
 
-        fn quicksort_by<T, F>(arr: &mut [T], compare: F)
-        where
-            F: Fn(&T, &T) -> Ordering,
+        #[cfg(not(any(
+            target_arch = "x86",
+            target_arch = "x86_64",
+            target_arch = "arm",
+            target_arch = "aarch64"
+        )))]
         {
-            if arr.len() <= 1 {
-                return;
-            }
-
-            let len = arr.len();
-            quicksort_helper(arr, 0, (len - 1) as isize, &compare);
-        }
-
-        #[ctor]
-        static TYPE_IDS: [(
-            TypeId,
-            for<'a> fn(&'a (dyn std::any::Any + 'static)) -> Primitive<'a>,
-        ); 30] = {
-            // NOTE: The types here *must* match the ones used above when `const_type_id` is available
-            let mut type_ids = type_ids![
-                usize,
-                u8,
-                u16,
-                u32,
-                u64,
-                isize,
-                i8,
-                i16,
-                i32,
-                i64,
-                f32,
-                f64,
-                char,
-                bool,
-                &'static str,
-            ];
-
-            quicksort_by(&mut type_ids, |&(ref a, _), &(ref b, _)| a.cmp(b));
-
-            type_ids
-        };
-
-        if let Ok(i) = TYPE_IDS.binary_search_by_key(&value.type_id(), |&(k, _)| k) {
-            Some((TYPE_IDS[i].1)(value))
-        } else {
+            let _ = value;
             None
         }
     }

--- a/src/internal/fmt.rs
+++ b/src/internal/fmt.rs
@@ -39,6 +39,52 @@ impl<'v> ValueBag<'v> {
             },
         })
     }
+
+    /// Get a value from a debuggable type without capturing support.
+    pub fn from_debug<T>(value: &'v T) -> Self
+    where
+        T: Debug,
+    {
+        ValueBag {
+            inner: Inner::Debug {
+                value,
+                type_id: None,
+            }
+        }
+    }
+
+    /// Get a value from a displayable type without capturing support.
+    pub fn from_display<T>(value: &'v T) -> Self
+    where
+        T: Display,
+    {
+        ValueBag {
+            inner: Inner::Display {
+                value,
+                type_id: None,
+            }
+        }
+    }
+
+    /// Get a value from a debuggable type without capturing support.
+    pub fn from_dyn_debug(value: &'v dyn Debug) -> Self {
+        ValueBag {
+            inner: Inner::Debug {
+                value,
+                type_id: None,
+            }
+        }
+    }
+
+    /// Get a value from a displayable type without capturing support.
+    pub fn from_dyn_display(value: &'v dyn Display) -> Self {
+        ValueBag {
+            inner: Inner::Display {
+                value,
+                type_id: None,
+            }
+        }
+    }
 }
 
 impl<'s, 'f> Slot<'s, 'f> {
@@ -241,28 +287,6 @@ impl<'v> Display for ValueBag<'v> {
     }
 }
 
-impl<'v> From<&'v (dyn Debug)> for ValueBag<'v> {
-    fn from(value: &'v (dyn Debug)) -> ValueBag<'v> {
-        ValueBag {
-            inner: Inner::Debug {
-                value,
-                type_id: None,
-            },
-        }
-    }
-}
-
-impl<'v> From<&'v (dyn Display)> for ValueBag<'v> {
-    fn from(value: &'v (dyn Display)) -> ValueBag<'v> {
-        ValueBag {
-            inner: Inner::Display {
-                value,
-                type_id: None,
-            },
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -285,7 +309,7 @@ mod tests {
     #[test]
     fn fmt_capture_args() {
         assert_eq!(
-            ValueBag::from(&format_args!("a {}", "value") as &dyn Debug).to_string(),
+            ValueBag::from_debug(&format_args!("a {}", "value")).to_string(),
             "a value"
         );
     }

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -39,7 +39,7 @@ pub(super) enum Inner<'v> {
     #[cfg(feature = "std")]
     /// An error.
     Error {
-        value: &'v dyn error::Error,
+        value: &'v (dyn error::Error + 'static),
         type_id: Option<TypeId>,
     },
 

--- a/src/internal/serde/v1.rs
+++ b/src/internal/serde/v1.rs
@@ -26,6 +26,19 @@ impl<'v> ValueBag<'v> {
             },
         })
     }
+
+    /// Get a value from a structured type without capturing support.
+    pub fn from_serde1<T>(value: &'v T) -> Self
+    where
+        T: Serialize,
+    {
+        ValueBag {
+            inner: Inner::Serde1 {
+                value,
+                type_id: None,
+            }
+        }
+    }
 }
 
 impl<'s, 'f> Slot<'s, 'f> {
@@ -159,17 +172,6 @@ impl<'v> serde1_lib::Serialize for ValueBag<'v> {
         self.visit(&mut visitor).map_err(|e| S::Error::custom(e))?;
 
         visitor.into_result()
-    }
-}
-
-impl<'v> From<&'v (dyn Serialize)> for ValueBag<'v> {
-    fn from(value: &'v (dyn Serialize)) -> ValueBag<'v> {
-        ValueBag {
-            inner: Inner::Serde1 {
-                value,
-                type_id: None,
-            },
-        }
     }
 }
 

--- a/src/internal/sval/v1.rs
+++ b/src/internal/sval/v1.rs
@@ -29,6 +29,29 @@ impl<'v> ValueBag<'v> {
             },
         })
     }
+
+    /// Get a value from a structured type without capturing support.
+    pub fn from_sval1<T>(value: &'v T) -> Self
+    where
+        T: Value,
+    {
+        ValueBag {
+            inner: Inner::Sval1 {
+                value,
+                type_id: None,
+            }
+        }
+    }
+
+    /// Get a value from an erased structured type.
+    pub fn from_dyn_sval1(value: &'v dyn Value) -> Self {
+        ValueBag {
+            inner: Inner::Sval1 {
+                value,
+                type_id: None,
+            }
+        }
+    }
 }
 
 impl<'s, 'f> Slot<'s, 'f> {
@@ -44,6 +67,11 @@ impl<'s, 'f> Slot<'s, 'f> {
         T: Value,
     {
         self.fill(|visitor| visitor.sval1(&value))
+    }
+
+    /// Fill the slot with a structured value.
+    pub fn fill_dyn_sval1(&mut self, value: &dyn Value) -> Result<(), Error> {
+        self.fill(|visitor| visitor.sval1(value))
     }
 }
 
@@ -107,17 +135,6 @@ impl<'v> Value for ValueBag<'v> {
             .map_err(Error::into_sval1)?;
 
         Ok(())
-    }
-}
-
-impl<'v> From<&'v (dyn Value)> for ValueBag<'v> {
-    fn from(value: &'v (dyn Value)) -> ValueBag<'v> {
-        ValueBag {
-            inner: Inner::Sval1 {
-                value,
-                type_id: None,
-            },
-        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ use self::internal::{Inner, Primitive, Visitor};
 /// # use std::fmt::Debug;
 /// use value_bag::ValueBag;
 ///
-/// let value = ValueBag::from(&42i32 as &dyn Debug);
+/// let value = ValueBag::from_debug(&42i32);
 ///
 /// assert_eq!(None, value.to_i32());
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Structured values.
 
-#![cfg_attr(value_bag_const_type_id, feature(const_type_id))]
+#![cfg_attr(value_bag_capture_const_type_id, feature(const_type_id))]
 #![no_std]
 
 #[cfg(any(feature = "std", test))]


### PR DESCRIPTION
This makes us always require our captured error types can produce a `&(dyn Error + 'static)`, which seems to be the most consistent abstract error type.