### PR TITLE
Add a zero-dependency Visit API to ValueBag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,15 @@ package = "sval"
 version = "1"
 package = "serde_test"
 
+[dev-dependencies.sval1_json]
+version = "1.0.0-alpha.4"
+features = ["std"]
+package = "sval_json"
+
+[dev-dependencies.serde1_json]
+version = "1"
+package = "serde_json"
+
 [dev-dependencies.wasm-bindgen]
 version = "0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,10 @@ std = []
 
 # Add support for sval
 sval = ["sval1"]
-
 sval1 = ["sval1_lib"]
 
 # Add support for `serde`
 serde = ["serde1"]
-
 serde1 = [
     "serde1_lib",
     "sval1_lib/serde1",

--- a/src/fill.rs
+++ b/src/fill.rs
@@ -2,7 +2,7 @@
 
 use crate::std::fmt;
 
-use super::internal::{Inner, Visitor};
+use super::internal::{Internal, InternalVisitor};
 use super::{Error, ValueBag};
 
 impl<'v> ValueBag<'v> {
@@ -12,7 +12,7 @@ impl<'v> ValueBag<'v> {
         T: Fill,
     {
         ValueBag {
-            inner: Inner::Fill { value },
+            inner: Internal::Fill { value },
         }
     }
 }
@@ -39,7 +39,7 @@ where
 /// A value slot to fill using the [`Fill`](trait.Fill.html) trait.
 pub struct Slot<'s, 'f> {
     filled: bool,
-    visitor: &'s mut dyn Visitor<'f>,
+    visitor: &'s mut dyn InternalVisitor<'f>,
 }
 
 impl<'s, 'f> fmt::Debug for Slot<'s, 'f> {
@@ -49,7 +49,7 @@ impl<'s, 'f> fmt::Debug for Slot<'s, 'f> {
 }
 
 impl<'s, 'f> Slot<'s, 'f> {
-    pub(super) fn new(visitor: &'s mut dyn Visitor<'f>) -> Self {
+    pub(super) fn new(visitor: &'s mut dyn InternalVisitor<'f>) -> Self {
         Slot {
             visitor,
             filled: false,
@@ -58,7 +58,7 @@ impl<'s, 'f> Slot<'s, 'f> {
 
     pub(super) fn fill<F>(&mut self, f: F) -> Result<(), Error>
     where
-        F: FnOnce(&mut dyn Visitor<'f>) -> Result<(), Error>,
+        F: FnOnce(&mut dyn InternalVisitor<'f>) -> Result<(), Error>,
     {
         assert!(!self.filled, "the slot has already been filled");
         self.filled = true;
@@ -77,7 +77,7 @@ impl<'s, 'f> Slot<'s, 'f> {
     where
         T: Into<ValueBag<'f>>,
     {
-        self.fill(|visitor| value.into().inner.visit(visitor))
+        self.fill(|visitor| value.into().inner.internal_visit(visitor))
     }
 }
 

--- a/src/internal/cast/mod.rs
+++ b/src/internal/cast/mod.rs
@@ -195,26 +195,26 @@ impl<'v> ValueBag<'v> {
         let target = TypeId::of::<T>();
         match self.inner {
             Internal::Debug {
-                type_id: Some(type_id),
+                type_id,
                 value,
             } if type_id == target => Some(unsafe { &*(value as *const _ as *const T) }),
             Internal::Display {
-                type_id: Some(type_id),
+                type_id,
                 value,
             } if type_id == target => Some(unsafe { &*(value as *const _ as *const T) }),
             #[cfg(feature = "error")]
             Internal::Error {
-                type_id: Some(type_id),
+                type_id,
                 value,
             } if type_id == target => Some(unsafe { &*(value as *const _ as *const T) }),
             #[cfg(feature = "sval1")]
             Internal::Sval1 {
-                type_id: Some(type_id),
+                type_id,
                 value,
             } if type_id == target => Some(unsafe { &*(value as *const _ as *const T) }),
             #[cfg(feature = "serde1")]
             Internal::Serde1 {
-                type_id: Some(type_id),
+                type_id,
                 value,
             } if type_id == target => Some(unsafe { &*(value as *const _ as *const T) }),
             _ => None,

--- a/src/internal/cast/mod.rs
+++ b/src/internal/cast/mod.rs
@@ -9,7 +9,7 @@ use crate::std::{any::TypeId, fmt};
 #[cfg(feature = "std")]
 use crate::std::{borrow::ToOwned, string::String};
 
-use super::{Internal, Primitive, InternalVisitor};
+use super::{Internal, InternalVisitor, Primitive};
 use crate::{Error, ValueBag};
 
 mod primitive;
@@ -194,29 +194,24 @@ impl<'v> ValueBag<'v> {
     pub fn downcast_ref<T: 'static>(&self) -> Option<&T> {
         let target = TypeId::of::<T>();
         match self.inner {
-            Internal::Debug {
-                type_id,
-                value,
-            } if type_id == target => Some(unsafe { &*(value as *const _ as *const T) }),
-            Internal::Display {
-                type_id,
-                value,
-            } if type_id == target => Some(unsafe { &*(value as *const _ as *const T) }),
+            Internal::Debug { type_id, value } if type_id == target => {
+                Some(unsafe { &*(value as *const _ as *const T) })
+            }
+            Internal::Display { type_id, value } if type_id == target => {
+                Some(unsafe { &*(value as *const _ as *const T) })
+            }
             #[cfg(feature = "error")]
-            Internal::Error {
-                type_id,
-                value,
-            } if type_id == target => Some(unsafe { &*(value as *const _ as *const T) }),
+            Internal::Error { type_id, value } if type_id == target => {
+                Some(unsafe { &*(value as *const _ as *const T) })
+            }
             #[cfg(feature = "sval1")]
-            Internal::Sval1 {
-                type_id,
-                value,
-            } if type_id == target => Some(unsafe { &*(value as *const _ as *const T) }),
+            Internal::Sval1 { type_id, value } if type_id == target => {
+                Some(unsafe { &*(value as *const _ as *const T) })
+            }
             #[cfg(feature = "serde1")]
-            Internal::Serde1 {
-                type_id,
-                value,
-            } if type_id == target => Some(unsafe { &*(value as *const _ as *const T) }),
+            Internal::Serde1 { type_id, value } if type_id == target => {
+                Some(unsafe { &*(value as *const _ as *const T) })
+            }
             _ => None,
         }
     }

--- a/src/internal/cast/mod.rs
+++ b/src/internal/cast/mod.rs
@@ -9,7 +9,7 @@ use crate::std::{any::TypeId, fmt};
 #[cfg(feature = "std")]
 use crate::std::{borrow::ToOwned, string::String};
 
-use super::{Inner, Primitive, Visitor};
+use super::{Internal, Primitive, InternalVisitor};
 use crate::{Error, ValueBag};
 
 mod primitive;
@@ -24,7 +24,7 @@ pub(super) fn type_id<T: 'static>() -> TypeId {
 /// This makes `ValueBag`s produced by `ValueBag::from_*` more useful
 pub(super) fn try_from_primitive<'v, T: 'static>(value: &'v T) -> Option<ValueBag<'v>> {
     primitive::from_any(value).map(|primitive| ValueBag {
-        inner: Inner::Primitive { value: primitive },
+        inner: Internal::Primitive { value: primitive },
     })
 }
 
@@ -194,26 +194,26 @@ impl<'v> ValueBag<'v> {
     pub fn downcast_ref<T: 'static>(&self) -> Option<&T> {
         let target = TypeId::of::<T>();
         match self.inner {
-            Inner::Debug {
+            Internal::Debug {
                 type_id: Some(type_id),
                 value,
             } if type_id == target => Some(unsafe { &*(value as *const _ as *const T) }),
-            Inner::Display {
+            Internal::Display {
                 type_id: Some(type_id),
                 value,
             } if type_id == target => Some(unsafe { &*(value as *const _ as *const T) }),
             #[cfg(feature = "error")]
-            Inner::Error {
+            Internal::Error {
                 type_id: Some(type_id),
                 value,
             } if type_id == target => Some(unsafe { &*(value as *const _ as *const T) }),
             #[cfg(feature = "sval1")]
-            Inner::Sval1 {
+            Internal::Sval1 {
                 type_id: Some(type_id),
                 value,
             } if type_id == target => Some(unsafe { &*(value as *const _ as *const T) }),
             #[cfg(feature = "serde1")]
-            Inner::Serde1 {
+            Internal::Serde1 {
                 type_id: Some(type_id),
                 value,
             } if type_id == target => Some(unsafe { &*(value as *const _ as *const T) }),
@@ -222,12 +222,12 @@ impl<'v> ValueBag<'v> {
     }
 }
 
-impl<'v> Inner<'v> {
+impl<'v> Internal<'v> {
     /// Cast the inner value to another type.
     fn cast(self) -> Cast<'v> {
         struct CastVisitor<'v>(Cast<'v>);
 
-        impl<'v> Visitor<'v> for CastVisitor<'v> {
+        impl<'v> InternalVisitor<'v> for CastVisitor<'v> {
             fn debug(&mut self, _: &dyn fmt::Debug) -> Result<(), Error> {
                 Ok(())
             }
@@ -285,23 +285,21 @@ impl<'v> Inner<'v> {
 
             #[cfg(feature = "sval1")]
             fn sval1(&mut self, v: &dyn super::sval::v1::Value) -> Result<(), Error> {
-                self.0 = super::sval::v1::cast(v);
-                Ok(())
+                super::sval::v1::internal_visit(v, self)
             }
 
             #[cfg(feature = "serde1")]
             fn serde1(&mut self, v: &dyn super::serde::v1::Serialize) -> Result<(), Error> {
-                self.0 = super::serde::v1::cast(v);
-                Ok(())
+                super::serde::v1::internal_visit(v, self)
             }
         }
 
-        if let Inner::Primitive { value } = self {
+        if let Internal::Primitive { value } = self {
             Cast::Primitive(value)
         } else {
             // If the erased value isn't a primitive then we visit it
             let mut cast = CastVisitor(Cast::Primitive(Primitive::None));
-            let _ = self.visit(&mut cast);
+            let _ = self.internal_visit(&mut cast);
             cast.0
         }
     }

--- a/src/internal/cast/primitive.rs
+++ b/src/internal/cast/primitive.rs
@@ -24,7 +24,7 @@ pub(super) fn from_any<'v, T: 'static>(value: &'v T) -> Option<Primitive<'v>> {
                         $(
                             const $const_ident: TypeId = TypeId::of::<$ty>();
                             const $option_ident: TypeId = TypeId::of::<Option<$ty>>();
-                        );*
+                        )*
 
                         match TypeId::of::<Self>() {
                             $(

--- a/src/internal/error.rs
+++ b/src/internal/error.rs
@@ -1,8 +1,4 @@
-use crate::{
-    fill::Slot,
-    std::error,
-    ValueBag,
-};
+use crate::{fill::Slot, std::error, ValueBag};
 
 use super::{cast, Internal};
 
@@ -23,9 +19,7 @@ impl<'v> ValueBag<'v> {
     /// Get a value from an erased value.
     pub fn from_dyn_error(value: &'v (dyn error::Error + 'static)) -> Self {
         ValueBag {
-            inner: Internal::AnonError {
-                value,
-            }
+            inner: Internal::AnonError { value },
         }
     }
 
@@ -54,7 +48,10 @@ impl<'s, 'f> Slot<'s, 'f> {
     }
 
     /// Fill the slot with an error.
-    pub fn fill_dyn_error(&mut self, value: &(dyn error::Error + 'static)) -> Result<(), crate::Error> {
+    pub fn fill_dyn_error(
+        &mut self,
+        value: &(dyn error::Error + 'static),
+    ) -> Result<(), crate::Error> {
         self.fill(|visitor| visitor.error(value))
     }
 }
@@ -105,6 +102,8 @@ mod tests {
     fn error_visit() {
         let err = io::Error::from(io::ErrorKind::Other);
 
-        ValueBag::from_dyn_error(&err).visit(TestVisit).expect("failed to visit value");
+        ValueBag::from_dyn_error(&err)
+            .visit(TestVisit)
+            .expect("failed to visit value");
     }
 }

--- a/src/internal/error.rs
+++ b/src/internal/error.rs
@@ -72,7 +72,10 @@ mod tests {
 
     use super::*;
 
-    use crate::std::{io, string::ToString};
+    use crate::{
+        std::{io, string::ToString},
+        test::*,
+    };
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
@@ -96,5 +99,13 @@ mod tests {
         assert!(ValueBag::capture_error(&err)
             .downcast_ref::<io::Error>()
             .is_some());
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn error_visit() {
+        let err = io::Error::from(io::ErrorKind::Other);
+
+        ValueBag::from_dyn_error(&err).visit(TestVisit).expect("failed to visit value");
     }
 }

--- a/src/internal/error.rs
+++ b/src/internal/error.rs
@@ -15,7 +15,7 @@ impl<'v> ValueBag<'v> {
         ValueBag {
             inner: Internal::Error {
                 value,
-                type_id: Some(cast::type_id::<T>()),
+                type_id: cast::type_id::<T>(),
             },
         }
     }
@@ -23,9 +23,8 @@ impl<'v> ValueBag<'v> {
     /// Get a value from an erased value.
     pub fn from_dyn_error(value: &'v (dyn error::Error + 'static)) -> Self {
         ValueBag {
-            inner: Internal::Error {
+            inner: Internal::AnonError {
                 value,
-                type_id: None,
             }
         }
     }

--- a/src/internal/error.rs
+++ b/src/internal/error.rs
@@ -4,7 +4,7 @@ use crate::{
     ValueBag,
 };
 
-use super::{cast, Inner};
+use super::{cast, Internal};
 
 impl<'v> ValueBag<'v> {
     /// Get a value from an error.
@@ -13,7 +13,7 @@ impl<'v> ValueBag<'v> {
         T: error::Error + 'static,
     {
         ValueBag {
-            inner: Inner::Error {
+            inner: Internal::Error {
                 value,
                 type_id: Some(cast::type_id::<T>()),
             },
@@ -23,7 +23,7 @@ impl<'v> ValueBag<'v> {
     /// Get a value from an erased value.
     pub fn from_dyn_error(value: &'v (dyn error::Error + 'static)) -> Self {
         ValueBag {
-            inner: Inner::Error {
+            inner: Internal::Error {
                 value,
                 type_id: None,
             }
@@ -31,9 +31,9 @@ impl<'v> ValueBag<'v> {
     }
 
     /// Try get an error from this value.
-    pub fn to_error<'a>(&'a self) -> Option<&(dyn Error + 'static)> {
+    pub fn to_borrowed_error(&self) -> Option<&(dyn Error + 'static)> {
         match self.inner {
-            Inner::Error { value, .. } => Some(value),
+            Internal::Error { value, .. } => Some(value),
             _ => None,
         }
     }
@@ -82,7 +82,7 @@ mod tests {
         assert_eq!(
             err.to_string(),
             ValueBag::capture_error(&err)
-                .to_error()
+                .to_borrowed_error()
                 .expect("invalid value")
                 .to_string()
         );

--- a/src/internal/fmt.rs
+++ b/src/internal/fmt.rs
@@ -46,9 +46,7 @@ impl<'v> ValueBag<'v> {
         T: Debug,
     {
         ValueBag {
-            inner: Internal::AnonDebug {
-                value,
-            }
+            inner: Internal::AnonDebug { value },
         }
     }
 
@@ -58,27 +56,21 @@ impl<'v> ValueBag<'v> {
         T: Display,
     {
         ValueBag {
-            inner: Internal::AnonDisplay {
-                value,
-            }
+            inner: Internal::AnonDisplay { value },
         }
     }
 
     /// Get a value from a debuggable type without capturing support.
     pub fn from_dyn_debug(value: &'v dyn Debug) -> Self {
         ValueBag {
-            inner: Internal::AnonDebug {
-                value,
-            }
+            inner: Internal::AnonDebug { value },
         }
     }
 
     /// Get a value from a displayable type without capturing support.
     pub fn from_dyn_display(value: &'v dyn Display) -> Self {
         ValueBag {
-            inner: Internal::AnonDisplay {
-                value,
-            }
+            inner: Internal::AnonDisplay { value },
         }
     }
 }
@@ -193,7 +185,8 @@ impl<'v> Debug for ValueBag<'v> {
             }
         }
 
-        self.internal_visit(&mut DebugVisitor(f)).map_err(|_| fmt::Error)?;
+        self.internal_visit(&mut DebugVisitor(f))
+            .map_err(|_| fmt::Error)?;
 
         Ok(())
     }
@@ -277,7 +270,8 @@ impl<'v> Display for ValueBag<'v> {
             }
         }
 
-        self.internal_visit(&mut DisplayVisitor(f)).map_err(|_| fmt::Error)?;
+        self.internal_visit(&mut DisplayVisitor(f))
+            .map_err(|_| fmt::Error)?;
 
         Ok(())
     }

--- a/src/internal/fmt.rs
+++ b/src/internal/fmt.rs
@@ -19,7 +19,7 @@ impl<'v> ValueBag<'v> {
         cast::try_from_primitive(value).unwrap_or(ValueBag {
             inner: Internal::Debug {
                 value,
-                type_id: Some(cast::type_id::<T>()),
+                type_id: cast::type_id::<T>(),
             },
         })
     }
@@ -35,7 +35,7 @@ impl<'v> ValueBag<'v> {
         cast::try_from_primitive(value).unwrap_or(ValueBag {
             inner: Internal::Display {
                 value,
-                type_id: Some(cast::type_id::<T>()),
+                type_id: cast::type_id::<T>(),
             },
         })
     }
@@ -46,9 +46,8 @@ impl<'v> ValueBag<'v> {
         T: Debug,
     {
         ValueBag {
-            inner: Internal::Debug {
+            inner: Internal::AnonDebug {
                 value,
-                type_id: None,
             }
         }
     }
@@ -59,9 +58,8 @@ impl<'v> ValueBag<'v> {
         T: Display,
     {
         ValueBag {
-            inner: Internal::Display {
+            inner: Internal::AnonDisplay {
                 value,
-                type_id: None,
             }
         }
     }
@@ -69,9 +67,8 @@ impl<'v> ValueBag<'v> {
     /// Get a value from a debuggable type without capturing support.
     pub fn from_dyn_debug(value: &'v dyn Debug) -> Self {
         ValueBag {
-            inner: Internal::Debug {
+            inner: Internal::AnonDebug {
                 value,
-                type_id: None,
             }
         }
     }
@@ -79,9 +76,8 @@ impl<'v> ValueBag<'v> {
     /// Get a value from a displayable type without capturing support.
     pub fn from_dyn_display(value: &'v dyn Display) -> Self {
         ValueBag {
-            inner: Internal::Display {
+            inner: Internal::AnonDisplay {
                 value,
-                type_id: None,
             }
         }
     }

--- a/src/internal/fmt.rs
+++ b/src/internal/fmt.rs
@@ -5,7 +5,7 @@
 
 use crate::{fill::Slot, std::fmt, Error, ValueBag};
 
-use super::{cast, Inner, Visitor};
+use super::{cast, Internal, InternalVisitor};
 
 impl<'v> ValueBag<'v> {
     /// Get a value from a debuggable type.
@@ -17,7 +17,7 @@ impl<'v> ValueBag<'v> {
         T: Debug + 'static,
     {
         cast::try_from_primitive(value).unwrap_or(ValueBag {
-            inner: Inner::Debug {
+            inner: Internal::Debug {
                 value,
                 type_id: Some(cast::type_id::<T>()),
             },
@@ -33,7 +33,7 @@ impl<'v> ValueBag<'v> {
         T: Display + 'static,
     {
         cast::try_from_primitive(value).unwrap_or(ValueBag {
-            inner: Inner::Display {
+            inner: Internal::Display {
                 value,
                 type_id: Some(cast::type_id::<T>()),
             },
@@ -46,7 +46,7 @@ impl<'v> ValueBag<'v> {
         T: Debug,
     {
         ValueBag {
-            inner: Inner::Debug {
+            inner: Internal::Debug {
                 value,
                 type_id: None,
             }
@@ -59,7 +59,7 @@ impl<'v> ValueBag<'v> {
         T: Display,
     {
         ValueBag {
-            inner: Inner::Display {
+            inner: Internal::Display {
                 value,
                 type_id: None,
             }
@@ -69,7 +69,7 @@ impl<'v> ValueBag<'v> {
     /// Get a value from a debuggable type without capturing support.
     pub fn from_dyn_debug(value: &'v dyn Debug) -> Self {
         ValueBag {
-            inner: Inner::Debug {
+            inner: Internal::Debug {
                 value,
                 type_id: None,
             }
@@ -79,7 +79,7 @@ impl<'v> ValueBag<'v> {
     /// Get a value from a displayable type without capturing support.
     pub fn from_dyn_display(value: &'v dyn Display) -> Self {
         ValueBag {
-            inner: Inner::Display {
+            inner: Internal::Display {
                 value,
                 type_id: None,
             }
@@ -123,7 +123,7 @@ impl<'v> Debug for ValueBag<'v> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         struct DebugVisitor<'a, 'b: 'a>(&'a mut fmt::Formatter<'b>);
 
-        impl<'a, 'b: 'a, 'v> Visitor<'v> for DebugVisitor<'a, 'b> {
+        impl<'a, 'b: 'a, 'v> InternalVisitor<'v> for DebugVisitor<'a, 'b> {
             fn debug(&mut self, v: &dyn Debug) -> Result<(), Error> {
                 Debug::fmt(v, self.0)?;
 
@@ -197,7 +197,7 @@ impl<'v> Debug for ValueBag<'v> {
             }
         }
 
-        self.visit(&mut DebugVisitor(f)).map_err(|_| fmt::Error)?;
+        self.internal_visit(&mut DebugVisitor(f)).map_err(|_| fmt::Error)?;
 
         Ok(())
     }
@@ -207,7 +207,7 @@ impl<'v> Display for ValueBag<'v> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         struct DisplayVisitor<'a, 'b: 'a>(&'a mut fmt::Formatter<'b>);
 
-        impl<'a, 'b: 'a, 'v> Visitor<'v> for DisplayVisitor<'a, 'b> {
+        impl<'a, 'b: 'a, 'v> InternalVisitor<'v> for DisplayVisitor<'a, 'b> {
             fn debug(&mut self, v: &dyn Debug) -> Result<(), Error> {
                 Debug::fmt(v, self.0)?;
 
@@ -281,7 +281,7 @@ impl<'v> Display for ValueBag<'v> {
             }
         }
 
-        self.visit(&mut DisplayVisitor(f)).map_err(|_| fmt::Error)?;
+        self.internal_visit(&mut DisplayVisitor(f)).map_err(|_| fmt::Error)?;
 
         Ok(())
     }

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -96,6 +96,7 @@ impl<'v> Internal<'v> {
     pub(super) fn internal_visit(self, visitor: &mut dyn InternalVisitor<'v>) -> Result<(), Error> {
         match self {
             Internal::Primitive { value } => value.internal_visit(visitor),
+
             Internal::Fill { value } => value.fill(&mut Slot::new(visitor)),
 
             Internal::Debug { value, .. } => visitor.debug(value),

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -4,10 +4,9 @@
 //! for optimizations or to support new external serialization frameworks.
 
 use crate::{
-    ValueBag,
     fill::{Fill, Slot},
     std::any::TypeId,
-    Error,
+    Error, ValueBag,
 };
 
 pub(super) mod cast;
@@ -31,9 +30,7 @@ pub(super) enum Internal<'v> {
     Fill { value: &'v dyn Fill },
 
     /// A debuggable value.
-    AnonDebug {
-        value: &'v dyn fmt::Debug,
-    },
+    AnonDebug { value: &'v dyn fmt::Debug },
     /// A debuggable value.
     Debug {
         value: &'v dyn fmt::Debug,
@@ -41,9 +38,7 @@ pub(super) enum Internal<'v> {
     },
 
     /// A displayable value.
-    AnonDisplay {
-        value: &'v dyn fmt::Display,
-    },
+    AnonDisplay { value: &'v dyn fmt::Display },
     /// A displayable value.
     Display {
         value: &'v dyn fmt::Display,
@@ -64,9 +59,7 @@ pub(super) enum Internal<'v> {
 
     #[cfg(feature = "sval1")]
     /// A structured value from `sval`.
-    AnonSval1 {
-        value: &'v dyn sval::v1::Value,
-    },
+    AnonSval1 { value: &'v dyn sval::v1::Value },
     #[cfg(feature = "sval1")]
     /// A structured value from `sval`.
     Sval1 {
@@ -76,9 +69,7 @@ pub(super) enum Internal<'v> {
 
     #[cfg(feature = "serde1")]
     /// A structured value from `serde`.
-    AnonSerde1 {
-        value: &'v dyn serde::v1::Serialize,
-    },
+    AnonSerde1 { value: &'v dyn serde::v1::Serialize },
     #[cfg(feature = "serde1")]
     /// A structured value from `serde`.
     Serde1 {
@@ -104,8 +95,8 @@ pub(super) enum Primitive<'v> {
 impl<'v> ValueBag<'v> {
     /// Get a value from an internal primitive.
     pub(super) fn from_primitive<T>(value: T) -> Self
-        where
-            T: Into<Primitive<'v>>,
+    where
+        T: Into<Primitive<'v>>,
     {
         ValueBag {
             inner: Internal::Primitive {
@@ -115,7 +106,10 @@ impl<'v> ValueBag<'v> {
     }
 
     /// Visit the value using an internal visitor.
-    pub(super) fn internal_visit(&self, visitor: &mut dyn InternalVisitor<'v>) -> Result<(), Error> {
+    pub(super) fn internal_visit(
+        &self,
+        visitor: &mut dyn InternalVisitor<'v>,
+    ) -> Result<(), Error> {
         self.inner.internal_visit(visitor)
     }
 }

--- a/src/internal/serde/v1.rs
+++ b/src/internal/serde/v1.rs
@@ -5,10 +5,7 @@
 
 use crate::{
     fill::Slot,
-    internal::{
-        cast,
-        Internal, InternalVisitor,
-    },
+    internal::{cast, Internal, InternalVisitor},
     std::fmt,
     Error, ValueBag,
 };
@@ -38,9 +35,7 @@ impl<'v> ValueBag<'v> {
         T: Serialize,
     {
         ValueBag {
-            inner: Internal::AnonSerde1 {
-                value,
-            }
+            inner: Internal::AnonSerde1 { value },
         }
     }
 }
@@ -173,7 +168,8 @@ impl<'v> serde1_lib::Serialize for ValueBag<'v> {
             result: None,
         };
 
-        self.internal_visit(&mut visitor).map_err(|e| S::Error::custom(e))?;
+        self.internal_visit(&mut visitor)
+            .map_err(|e| S::Error::custom(e))?;
 
         visitor.into_result()
     }
@@ -195,7 +191,10 @@ pub(in crate::internal) fn sval1(
     Ok(())
 }
 
-pub(crate) fn internal_visit<'v>(v: &dyn Serialize, visitor: &mut dyn InternalVisitor<'v>) -> Result<(), Error> {
+pub(crate) fn internal_visit<'v>(
+    v: &dyn Serialize,
+    visitor: &mut dyn InternalVisitor<'v>,
+) -> Result<(), Error> {
     struct VisitorSerializer<'a, 'v>(&'a mut dyn InternalVisitor<'v>);
 
     impl<'a, 'v> serde1_lib::Serializer for VisitorSerializer<'a, 'v> {
@@ -382,7 +381,6 @@ impl Error {
     }
 }
 
-
 #[derive(Debug)]
 struct Unsupported;
 
@@ -394,8 +392,8 @@ impl fmt::Display for Unsupported {
 
 impl serde1_lib::ser::Error for Unsupported {
     fn custom<T>(_: T) -> Self
-        where
-            T: fmt::Display,
+    where
+        T: fmt::Display,
     {
         Unsupported
     }
@@ -521,12 +519,24 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn serde1_visit() {
-        ValueBag::from_serde1(&42u64).visit(TestVisit).expect("failed to visit value");
-        ValueBag::from_serde1(&-42i64).visit(TestVisit).expect("failed to visit value");
-        ValueBag::from_serde1(&11f64).visit(TestVisit).expect("failed to visit value");
-        ValueBag::from_serde1(&true).visit(TestVisit).expect("failed to visit value");
-        ValueBag::from_serde1(&"some string").visit(TestVisit).expect("failed to visit value");
-        ValueBag::from_serde1(&'n').visit(TestVisit).expect("failed to visit value");
+        ValueBag::from_serde1(&42u64)
+            .visit(TestVisit)
+            .expect("failed to visit value");
+        ValueBag::from_serde1(&-42i64)
+            .visit(TestVisit)
+            .expect("failed to visit value");
+        ValueBag::from_serde1(&11f64)
+            .visit(TestVisit)
+            .expect("failed to visit value");
+        ValueBag::from_serde1(&true)
+            .visit(TestVisit)
+            .expect("failed to visit value");
+        ValueBag::from_serde1(&"some string")
+            .visit(TestVisit)
+            .expect("failed to visit value");
+        ValueBag::from_serde1(&'n')
+            .visit(TestVisit)
+            .expect("failed to visit value");
     }
 
     #[test]

--- a/src/internal/serde/v1.rs
+++ b/src/internal/serde/v1.rs
@@ -413,7 +413,7 @@ mod tests {
     wasm_bindgen_test_configure!(run_in_browser);
 
     use super::*;
-    use crate::test::Token;
+    use crate::test::*;
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
@@ -517,6 +517,17 @@ mod tests {
             format!("{:04?}", 42u64),
             format!("{:04?}", ValueBag::capture_serde1(&TestSerde)),
         );
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn serde1_visit() {
+        ValueBag::from_serde1(&42u64).visit(TestVisit).expect("failed to visit value");
+        ValueBag::from_serde1(&-42i64).visit(TestVisit).expect("failed to visit value");
+        ValueBag::from_serde1(&11f64).visit(TestVisit).expect("failed to visit value");
+        ValueBag::from_serde1(&true).visit(TestVisit).expect("failed to visit value");
+        ValueBag::from_serde1(&"some string").visit(TestVisit).expect("failed to visit value");
+        ValueBag::from_serde1(&'n').visit(TestVisit).expect("failed to visit value");
     }
 
     #[test]

--- a/src/internal/serde/v1.rs
+++ b/src/internal/serde/v1.rs
@@ -27,7 +27,7 @@ impl<'v> ValueBag<'v> {
         cast::try_from_primitive(value).unwrap_or(ValueBag {
             inner: Internal::Serde1 {
                 value,
-                type_id: Some(cast::type_id::<T>()),
+                type_id: cast::type_id::<T>(),
             },
         })
     }
@@ -38,9 +38,8 @@ impl<'v> ValueBag<'v> {
         T: Serialize,
     {
         ValueBag {
-            inner: Internal::Serde1 {
+            inner: Internal::AnonSerde1 {
                 value,
-                type_id: None,
             }
         }
     }

--- a/src/internal/sval/v1.rs
+++ b/src/internal/sval/v1.rs
@@ -218,7 +218,7 @@ mod tests {
     wasm_bindgen_test_configure!(run_in_browser);
 
     use super::*;
-    use crate::test::Token;
+    use crate::test::*;
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
@@ -322,6 +322,17 @@ mod tests {
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn sval1_visit() {
+        ValueBag::from_dyn_sval1(&42u64).visit(TestVisit).expect("failed to visit value");
+        ValueBag::from_dyn_sval1(&-42i64).visit(TestVisit).expect("failed to visit value");
+        ValueBag::from_dyn_sval1(&11f64).visit(TestVisit).expect("failed to visit value");
+        ValueBag::from_dyn_sval1(&true).visit(TestVisit).expect("failed to visit value");
+        ValueBag::from_dyn_sval1(&"some string").visit(TestVisit).expect("failed to visit value");
+        ValueBag::from_dyn_sval1(&'n').visit(TestVisit).expect("failed to visit value");
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg(feature = "serde1")]
     fn sval1_serde1() {
         use serde1_test::{assert_ser_tokens, Token};
@@ -335,6 +346,22 @@ mod tests {
         }
 
         assert_ser_tokens(&ValueBag::capture_sval1(&TestSval), &[Token::U64(42)]);
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg(feature = "std")]
+    fn sval1_visit_error() {
+        use crate::{
+            std::{error, io},
+            internal::sval::v1 as sval,
+        };
+
+        let err: &(dyn error::Error + 'static) = &io::Error::from(io::ErrorKind::Other);
+        let value: &dyn sval::Value = &err;
+
+        // Ensure that an error captured through `sval` can be visited as an error
+        ValueBag::from_dyn_sval1(value).visit(TestVisit).expect("failed to visit value");
     }
 
     #[cfg(feature = "std")]

--- a/src/internal/sval/v1.rs
+++ b/src/internal/sval/v1.rs
@@ -25,7 +25,7 @@ impl<'v> ValueBag<'v> {
         cast::try_from_primitive(value).unwrap_or(ValueBag {
             inner: Internal::Sval1 {
                 value,
-                type_id: Some(cast::type_id::<T>()),
+                type_id: cast::type_id::<T>(),
             },
         })
     }
@@ -36,9 +36,8 @@ impl<'v> ValueBag<'v> {
         T: Value,
     {
         ValueBag {
-            inner: Internal::Sval1 {
+            inner: Internal::AnonSval1 {
                 value,
-                type_id: None,
             }
         }
     }
@@ -46,9 +45,8 @@ impl<'v> ValueBag<'v> {
     /// Get a value from an erased structured type.
     pub fn from_dyn_sval1(value: &'v dyn Value) -> Self {
         ValueBag {
-            inner: Internal::Sval1 {
+            inner: Internal::AnonSval1 {
                 value,
-                type_id: None,
             }
         }
     }

--- a/src/internal/sval/v1.rs
+++ b/src/internal/sval/v1.rs
@@ -5,10 +5,7 @@
 
 use crate::{
     fill::Slot,
-    internal::{
-        cast,
-        Internal, InternalVisitor,
-    },
+    internal::{cast, Internal, InternalVisitor},
     std::fmt,
     Error, ValueBag,
 };
@@ -36,18 +33,14 @@ impl<'v> ValueBag<'v> {
         T: Value,
     {
         ValueBag {
-            inner: Internal::AnonSval1 {
-                value,
-            }
+            inner: Internal::AnonSval1 { value },
         }
     }
 
     /// Get a value from an erased structured type.
     pub fn from_dyn_sval1(value: &'v dyn Value) -> Self {
         ValueBag {
-            inner: Internal::AnonSval1 {
-                value,
-            }
+            inner: Internal::AnonSval1 { value },
         }
     }
 }
@@ -150,7 +143,10 @@ where
     sval1_lib::serde::v1::serialize(s, v)
 }
 
-pub(crate) fn internal_visit<'v>(v: &dyn Value, visitor: &mut dyn InternalVisitor<'v>) -> Result<(), Error> {
+pub(crate) fn internal_visit<'v>(
+    v: &dyn Value,
+    visitor: &mut dyn InternalVisitor<'v>,
+) -> Result<(), Error> {
     struct VisitorStream<'a, 'v>(&'a mut dyn InternalVisitor<'v>);
 
     impl<'a, 'v> sval1_lib::stream::Stream for VisitorStream<'a, 'v> {
@@ -260,7 +256,6 @@ mod tests {
                 .expect("invalid value")
         );
 
-
         #[cfg(feature = "std")]
         assert_eq!(
             "a string",
@@ -321,12 +316,24 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn sval1_visit() {
-        ValueBag::from_dyn_sval1(&42u64).visit(TestVisit).expect("failed to visit value");
-        ValueBag::from_dyn_sval1(&-42i64).visit(TestVisit).expect("failed to visit value");
-        ValueBag::from_dyn_sval1(&11f64).visit(TestVisit).expect("failed to visit value");
-        ValueBag::from_dyn_sval1(&true).visit(TestVisit).expect("failed to visit value");
-        ValueBag::from_dyn_sval1(&"some string").visit(TestVisit).expect("failed to visit value");
-        ValueBag::from_dyn_sval1(&'n').visit(TestVisit).expect("failed to visit value");
+        ValueBag::from_dyn_sval1(&42u64)
+            .visit(TestVisit)
+            .expect("failed to visit value");
+        ValueBag::from_dyn_sval1(&-42i64)
+            .visit(TestVisit)
+            .expect("failed to visit value");
+        ValueBag::from_dyn_sval1(&11f64)
+            .visit(TestVisit)
+            .expect("failed to visit value");
+        ValueBag::from_dyn_sval1(&true)
+            .visit(TestVisit)
+            .expect("failed to visit value");
+        ValueBag::from_dyn_sval1(&"some string")
+            .visit(TestVisit)
+            .expect("failed to visit value");
+        ValueBag::from_dyn_sval1(&'n')
+            .visit(TestVisit)
+            .expect("failed to visit value");
     }
 
     #[test]
@@ -351,15 +358,17 @@ mod tests {
     #[cfg(feature = "std")]
     fn sval1_visit_error() {
         use crate::{
-            std::{error, io},
             internal::sval::v1 as sval,
+            std::{error, io},
         };
 
         let err: &(dyn error::Error + 'static) = &io::Error::from(io::ErrorKind::Other);
         let value: &dyn sval::Value = &err;
 
         // Ensure that an error captured through `sval` can be visited as an error
-        ValueBag::from_dyn_sval1(value).visit(TestVisit).expect("failed to visit value");
+        ValueBag::from_dyn_sval1(value)
+            .visit(TestVisit)
+            .expect("failed to visit value");
     }
 
     #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,18 +121,224 @@ pub use self::error::Error;
 ///
 /// Once you have a `ValueBag` there are also a few ways to inspect it:
 ///
-/// - Using the `Debug`, `Display`, `Serialize`, and `Stream` trait implementations.
+/// - Using `std::fmt`
+/// - Using `sval`
+/// - Using `serde`
 /// - Using the `ValueBag::visit` method.
 /// - Using the `ValueBag::to_*` methods.
 /// - Using the `ValueBag::downcast_ref` method.
 ///
-/// ## Using the trait implementations
-///
 /// ## Using the `ValueBag::visit` method
+///
+/// The `visit` module provides a simple visitor API that can be used to inspect
+/// the structure of primitives stored in a `ValueBag`.
+/// More complex datatypes can then be handled using `std::fmt`, `sval`, or `serde`.
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # fn escape(buf: &[u8]) -> &[u8] { buf }
+/// # fn itoa_fmt<T>(num: T) -> Vec<u8> { vec![] }
+/// # fn ryu_fmt<T>(num: T) -> Vec<u8> { vec![] }
+/// # use std::io::Write;
+/// use value_bag::{ValueBag, Error, visit::Visit};
+///
+/// // Implement some simple custom serialization
+/// struct MyVisit(Vec<u8>);
+/// impl<'v> Visit<'v> for MyVisit {
+///     fn visit_any(&mut self, v: ValueBag) -> Result<(), Error> {
+///         // Fallback to `Debug` if we didn't visit the value specially
+///         write!(&mut self.0, "{:?}", v).map_err(|_| Error::msg("failed to write value"))
+///     }
+///
+///     fn visit_u64(&mut self, v: u64) -> Result<(), Error> {
+///         self.0.extend_from_slice(itoa_fmt(v).as_slice());
+///         Ok(())
+///     }
+///
+///     fn visit_i64(&mut self, v: i64) -> Result<(), Error> {
+///         self.0.extend_from_slice(itoa_fmt(v).as_slice());
+///         Ok(())
+///     }
+///
+///     fn visit_f64(&mut self, v: f64) -> Result<(), Error> {
+///         self.0.extend_from_slice(ryu_fmt(v).as_slice());
+///         Ok(())
+///     }
+///
+///     fn visit_str(&mut self, v: &str) -> Result<(), Error> {
+///         self.0.push(b'\"');
+///         self.0.extend_from_slice(escape(v.as_bytes()));
+///         self.0.push(b'\"');
+///         Ok(())
+///     }
+///
+///     fn visit_bool(&mut self, v: bool) -> Result<(), Error> {
+///         self.0.extend_from_slice(if v { b"true" } else { b"false" });
+///         Ok(())
+///     }
+/// }
+///
+/// let value = ValueBag::from(42i64);
+///
+/// let mut visitor = MyVisit(vec![]);
+/// value.visit(&mut visitor)?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// ## Using `std::fmt`
+///
+/// Any `ValueBag` can be formatted using the `std::fmt` machinery as either `Debug`
+/// or `Display`.
+///
+/// ```
+/// use value_bag::ValueBag;
+///
+/// let value = ValueBag::from(true);
+///
+/// assert_eq!("true", format!("{:?}", value));
+/// ```
+///
+/// ## Using `sval`
+///
+/// When the `sval1` feature is enabled, any `ValueBag` can be serialized using `sval`.
+/// This makes it possible to visit any typed structure captured in the `ValueBag`,
+/// including complex datatypes like maps and sequences.
+///
+/// `sval` doesn't need to allocate so can be used in no-std environments.
+///
+/// First, enable the `sval1` feature in your `Cargo.toml`:
+///
+/// ```toml
+/// [dependencies.value-bag]
+/// features = ["sval1"]
+/// ```
+///
+/// Then stream the contents of the `ValueBag` using `sval`.
+///
+/// ```
+/// #![cfg(feature = "sval1")]
+/// # extern crate sval1_json as sval_json;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use value_bag::ValueBag;
+///
+/// let value = ValueBag::from(42i64);
+/// let json = sval_json::to_string(value)?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// ```
+/// #![cfg(feature = "sval1")]
+/// # extern crate sval1_lib as sval;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # fn escape(buf: &[u8]) -> &[u8] { buf }
+/// # fn itoa_fmt<T>(num: T) -> Vec<u8> { vec![] }
+/// # fn ryu_fmt<T>(num: T) -> Vec<u8> { vec![] }
+/// use value_bag::ValueBag;
+/// use sval::stream::{self, Stream};
+///
+/// // Implement some simple custom serialization
+/// struct MyStream(Vec<u8>);
+/// impl Stream for MyStream {
+///     fn u64(&mut self, v: u64) -> stream::Result {
+///         self.0.extend_from_slice(itoa_fmt(v).as_slice());
+///         Ok(())
+///     }
+///
+///     fn i64(&mut self, v: i64) -> stream::Result {
+///         self.0.extend_from_slice(itoa_fmt(v).as_slice());
+///         Ok(())
+///     }
+///
+///     fn f64(&mut self, v: f64) -> stream::Result {
+///         self.0.extend_from_slice(ryu_fmt(v).as_slice());
+///         Ok(())
+///     }
+///
+///     fn str(&mut self, v: &str) -> stream::Result {
+///         self.0.push(b'\"');
+///         self.0.extend_from_slice(escape(v.as_bytes()));
+///         self.0.push(b'\"');
+///         Ok(())
+///     }
+///
+///     fn bool(&mut self, v: bool) -> stream::Result {
+///         self.0.extend_from_slice(if v { b"true" } else { b"false" });
+///         Ok(())
+///     }
+/// }
+///
+/// let value = ValueBag::from(42i64);
+///
+/// let mut stream = MyStream(vec![]);
+/// sval::stream(&mut stream, &value)?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// ## Using `serde`
+///
+/// When the `serde1` feature is enabled, any `ValueBag` can be serialized using `serde`.
+/// This makes it possible to visit any typed structure captured in the `ValueBag`,
+/// including complex datatypes like maps and sequences.
+///
+/// `serde` doesn't need to allocate so can be used in no-std environments.
+///
+/// First, enable the `serde1` feature in your `Cargo.toml`:
+///
+/// ```toml
+/// [dependencies.value-bag]
+/// features = ["serde1"]
+/// ```
+///
+/// Then stream the contents of the `ValueBag` using `serde`.
+///
+/// ```
+/// #![cfg(feature = "serde1")]
+/// # extern crate serde1_json as serde_json;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use value_bag::ValueBag;
+///
+/// let value = ValueBag::from(42i64);
+/// let json = serde_json::to_string(&value)?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Also see [`serde.rs`](https://serde.rs) for more examples of writing your own serializers.
 ///
 /// ## Using the `ValueBag::to_*` methods
 ///
+/// `ValueBag` provides a set of methods for attempting to pull a concrete value out.
+/// These are useful for ad-hoc analysis but aren't intended for exhaustively serializing
+/// the contents of a `ValueBag`.
+///
+/// ```
+/// use value_bag::ValueBag;
+///
+/// let value = ValueBag::capture_display(&42u64);
+///
+/// assert_eq!(Some(42u16), value.to_u16());
+/// ```
+///
 /// ## Using the `ValueBag::downcast_ref` method
+///
+/// When a `ValueBag` is created using one of the `capture_*` constructors, it can be downcast
+/// back to its original value.
+/// This can also be useful for ad-hoc analysis where there's a common possible non-primitive
+/// type that could be captured.
+///
+/// ```
+/// # #[derive(Debug)] struct SystemTime;
+/// # fn now() -> SystemTime { SystemTime }
+/// use value_bag::ValueBag;
+///
+/// let timestamp = now();
+/// let value = ValueBag::capture_debug(&timestamp);
+///
+/// assert!(value.downcast_ref::<SystemTime>().is_some());
+/// ```
 #[derive(Clone)]
 pub struct ValueBag<'v> {
     inner: internal::Internal<'v>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,9 +20,9 @@ extern crate core as std;
 
 mod error;
 pub mod fill;
-pub mod visit;
 mod impls;
 mod internal;
+pub mod visit;
 
 #[cfg(any(test, feature = "test"))]
 pub mod test;
@@ -83,11 +83,11 @@ pub use self::error::Error;
 ///
 /// ## Using the `Fill` API
 ///
-/// The `Fill` trait is a way to bridge APIs that may not be directly
+/// The [`fill`] module provides a way to bridge APIs that may not be directly
 /// compatible with other constructor methods.
 ///
-/// The `Fill` trait is automatically implemented for `Fn`, so can usually
-/// be used in libraries that can't implement the trait themselves:
+/// The `Fill` trait is automatically implemented for closures, so can usually
+/// be used in libraries that can't implement the trait themselves.
 ///
 /// ```
 /// use value_bag::{ValueBag, fill::Slot};
@@ -134,7 +134,7 @@ pub use self::error::Error;
 ///
 /// ## Using the `ValueBag::visit` method
 ///
-/// The `visit` module provides a simple visitor API that can be used to inspect
+/// The [`visit`] module provides a simple visitor API that can be used to inspect
 /// the structure of primitives stored in a `ValueBag`.
 /// More complex datatypes can then be handled using `std::fmt`, `sval`, or `serde`.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,21 +82,23 @@ pub use self::error::Error;
 /// The `Fill` trait is a way to bridge APIs that may not be directly
 /// compatible with other constructor methods.
 ///
+/// The `Fill` trait is automatically implemented for `Fn`, so can usually
+/// be used in libraries that can't implement the trait themselves:
+///
 /// ```
-/// use value_bag::{ValueBag, Error, fill::{Slot, Fill}};
+/// use value_bag::{ValueBag, fill::Slot};
 ///
-/// struct FillSigned;
+/// let value = ValueBag::from_fill(&|slot: &mut Slot| {
+///     #[derive(Debug)]
+///     struct MyShortLivedValue;
 ///
-/// impl Fill for FillSigned {
-///     fn fill(&self, slot: &mut Slot) -> Result<(), Error> {
-///         slot.fill_any(42i32)
-///     }
-/// }
+///     slot.fill_debug(&MyShortLivedValue)
+/// });
 ///
-/// let value = ValueBag::from_fill(&FillSigned);
-///
-/// assert_eq!(Some(42), value.to_i32());
+/// assert_eq!("MyShortLivedValue", format!("{:?}", value));
 /// ```
+///
+/// The trait can also be implemented manually:
 ///
 /// ```
 /// # use std::fmt::Debug;
@@ -120,8 +122,17 @@ pub use self::error::Error;
 /// Once you have a `ValueBag` there are also a few ways to inspect it:
 ///
 /// - Using the `Debug`, `Display`, `Serialize`, and `Stream` trait implementations.
+/// - Using the `ValueBag::visit` method.
 /// - Using the `ValueBag::to_*` methods.
 /// - Using the `ValueBag::downcast_ref` method.
+///
+/// ## Using the trait implementations
+///
+/// ## Using the `ValueBag::visit` method
+///
+/// ## Using the `ValueBag::to_*` methods
+///
+/// ## Using the `ValueBag::downcast_ref` method
 #[derive(Clone)]
 pub struct ValueBag<'v> {
     inner: internal::Internal<'v>,

--- a/src/test.rs
+++ b/src/test.rs
@@ -64,7 +64,7 @@ impl<'v> ValueBag<'v> {
     pub fn to_token(&self) -> Token {
         struct TestVisitor(Option<Token>);
 
-        impl<'v> internal::Visitor<'v> for TestVisitor {
+        impl<'v> internal::InternalVisitor<'v> for TestVisitor {
             fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error> {
                 self.0 = Some(Token::Str(format!("{:?}", v)));
                 Ok(())
@@ -125,7 +125,7 @@ impl<'v> ValueBag<'v> {
         }
 
         let mut visitor = TestVisitor(None);
-        self.visit(&mut visitor).unwrap();
+        self.internal_visit(&mut visitor).unwrap();
 
         visitor.0.unwrap()
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,8 +1,10 @@
 //! Test support for inspecting values.
 
 use crate::{
+    internal,
     std::{fmt, str, string::String},
-    internal, visit::Visit, Error, ValueBag
+    visit::Visit,
+    Error, ValueBag,
 };
 
 pub(crate) trait IntoValueBag<'v> {
@@ -42,12 +44,18 @@ pub enum Token {
     Serde(Serde),
 }
 
+/**
+A value that was captured using `sval`.
+*/
 #[derive(Debug, PartialEq)]
 #[non_exhaustive]
 pub struct Sval {
     pub version: u32,
 }
 
+/**
+A value that was captured using `serde`.
+*/
 #[derive(Debug, PartialEq)]
 #[non_exhaustive]
 pub struct Serde {
@@ -179,7 +187,10 @@ impl<'v> Visit<'v> for TestVisit {
     }
 
     #[cfg(feature = "error")]
-    fn visit_borrowed_error(&mut self, err: &'v (dyn crate::std::error::Error + 'static)) -> Result<(), Error> {
+    fn visit_borrowed_error(
+        &mut self,
+        err: &'v (dyn crate::std::error::Error + 'static),
+    ) -> Result<(), Error> {
         assert!(err.downcast_ref::<crate::std::io::Error>().is_some());
         Ok(())
     }

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -1,0 +1,290 @@
+//! Primitive value visitor.
+
+use crate::{
+    ValueBag, Error,
+    internal::{self, InternalVisitor},
+};
+
+/// A visitor for a `ValueBag`.
+pub trait Visit<'v> {
+    /// Visit a `ValueBag`.
+    ///
+    /// This is the only required method on `Visit` and acts as a fallback for any
+    /// more specific methods that aren't overridden.
+    /// The `ValueBag` may be formatted using its fmt::Debug` or `fmt::Display` implementation,
+    /// or serialized using its `sval::Value` or `serde::Serialize` implementation.
+    fn visit_any(&mut self, value: ValueBag) -> Result<(), Error>;
+
+    /// Visit an unsigned integer.
+    #[cfg(not(test))]
+    fn visit_u64(&mut self, value: u64) -> Result<(), Error> {
+        self.visit_any(value.into())
+    }
+    #[cfg(test)]
+    fn visit_u64(&mut self, value: u64) -> Result<(), Error>;
+
+    /// Visit a signed integer.
+    #[cfg(not(test))]
+    fn visit_i64(&mut self, value: i64) -> Result<(), Error> {
+        self.visit_any(value.into())
+    }
+    #[cfg(test)]
+    fn visit_i64(&mut self, value: i64) -> Result<(), Error>;
+
+    /// Visit a floating point.
+    #[cfg(not(test))]
+    fn visit_f64(&mut self, value: f64) -> Result<(), Error> {
+        self.visit_any(value.into())
+    }
+    #[cfg(test)]
+    fn visit_f64(&mut self, value: f64) -> Result<(), Error>;
+
+    /// Visit a boolean.
+    #[cfg(not(test))]
+    fn visit_bool(&mut self, value: bool) -> Result<(), Error> {
+        self.visit_any(value.into())
+    }
+    #[cfg(test)]
+    fn visit_bool(&mut self, value: bool) -> Result<(), Error>;
+
+    /// Visit a string.
+    #[cfg(not(test))]
+    fn visit_str(&mut self, value: &str) -> Result<(), Error> {
+        self.visit_any(value.into())
+    }
+    #[cfg(test)]
+    fn visit_str(&mut self, value: &str) -> Result<(), Error>;
+
+    /// Visit a string.
+    #[cfg(not(test))]
+    fn visit_borrowed_str(&mut self, value: &'v str) -> Result<(), Error> {
+        self.visit_str(value)
+    }
+    #[cfg(test)]
+    fn visit_borrowed_str(&mut self, value: &'v str) -> Result<(), Error>;
+
+    /// Visit a Unicode character.
+    #[cfg(not(test))]
+    fn visit_char(&mut self, value: char) -> Result<(), Error> {
+        let mut b = [0; 4];
+        self.visit_str(&*value.encode_utf8(&mut b))
+    }
+    #[cfg(test)]
+    fn visit_char(&mut self, value: char) -> Result<(), Error>;
+
+    /// Visit an error.
+    #[cfg(not(test))]
+    #[cfg(feature = "error")]
+    fn visit_error(&mut self, err: &(dyn crate::std::error::Error + 'static)) -> Result<(), Error> {
+        self.visit_any(ValueBag::from_dyn_error(err))
+    }
+    #[cfg(test)]
+    #[cfg(feature = "error")]
+    fn visit_error(&mut self, err: &(dyn crate::std::error::Error + 'static)) -> Result<(), Error>;
+
+    /// Visit an error.
+    #[cfg(not(test))]
+    #[cfg(feature = "error")]
+    fn visit_borrowed_error(&mut self, err: &'v (dyn crate::std::error::Error + 'static)) -> Result<(), Error> {
+        self.visit_any(ValueBag::from_dyn_error(err))
+    }
+    #[cfg(test)]
+    #[cfg(feature = "error")]
+    fn visit_borrowed_error(&mut self, err: &'v (dyn crate::std::error::Error + 'static)) -> Result<(), Error>;
+}
+
+impl<'v> ValueBag<'v> {
+    pub fn visit(&self, visitor: impl Visit<'v>) -> Result<(), Error> {
+        struct Visitor<V>(V);
+
+        impl<'v, V> InternalVisitor<'v> for Visitor<V> where V: Visit<'v> {
+            fn debug(&mut self, v: &dyn internal::fmt::Debug) -> Result<(), Error> {
+                self.0.visit_any(ValueBag::from_dyn_debug(v))
+            }
+
+            fn display(&mut self, v: &dyn internal::fmt::Display) -> Result<(), Error> {
+                self.0.visit_any(ValueBag::from_dyn_display(v))
+            }
+
+            fn u64(&mut self, v: u64) -> Result<(), Error> {
+                self.0.visit_u64(v)
+            }
+
+            fn i64(&mut self, v: i64) -> Result<(), Error> {
+                self.0.visit_i64(v)
+            }
+
+            fn f64(&mut self, v: f64) -> Result<(), Error> {
+                self.0.visit_f64(v)
+            }
+
+            fn bool(&mut self, v: bool) -> Result<(), Error> {
+                self.0.visit_bool(v)
+            }
+
+            fn char(&mut self, v: char) -> Result<(), Error> {
+                self.0.visit_char(v)
+            }
+
+            fn str(&mut self, v: &str) -> Result<(), Error> {
+                self.0.visit_str(v)
+            }
+
+            fn borrowed_str(&mut self, v: &'v str) -> Result<(), Error> {
+                self.0.visit_borrowed_str(v)
+            }
+
+            fn none(&mut self) -> Result<(), Error> {
+                self.0.visit_any(ValueBag::from(()))
+            }
+
+            #[cfg(feature = "error")]
+            fn error(&mut self, v: &(dyn internal::error::Error + 'static)) -> Result<(), Error> {
+                self.0.visit_error(v)
+            }
+
+            #[cfg(feature = "error")]
+            fn borrowed_error(&mut self, v: &'v (dyn internal::error::Error + 'static)) -> Result<(), Error> {
+                self.0.visit_borrowed_error(v)
+            }
+
+            #[cfg(feature = "sval1")]
+            fn sval1(&mut self, v: &dyn internal::sval::v1::Value) -> Result<(), Error> {
+                internal::sval::v1::internal_visit(v, self)
+            }
+
+            #[cfg(feature = "serde1")]
+            fn serde1(&mut self, v: &dyn internal::serde::v1::Serialize) -> Result<(), Error> {
+                internal::serde::v1::internal_visit(v, self)
+            }
+        }
+
+        self.internal_visit(&mut Visitor(visitor))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn visit_structured() {
+        struct VisitStructured;
+
+        impl<'v> Visit<'v> for VisitStructured {
+            fn visit_any(&mut self, v: ValueBag) -> Result<(), Error> {
+                panic!("unexpected value: {}", v)
+            }
+
+            fn visit_i64(&mut self, v: i64) -> Result<(), Error> {
+                assert_eq!(-42i64, v);
+                Ok(())
+            }
+
+            fn visit_u64(&mut self, v: u64) -> Result<(), Error> {
+                assert_eq!(42u64, v);
+                Ok(())
+            }
+
+            fn visit_f64(&mut self, v: f64) -> Result<(), Error> {
+                assert_eq!(11f64, v);
+                Ok(())
+            }
+
+            fn visit_bool(&mut self, v: bool) -> Result<(), Error> {
+                assert_eq!(true, v);
+                Ok(())
+            }
+
+            fn visit_str(&mut self, v: &str) -> Result<(), Error> {
+                assert_eq!("some string", v);
+                Ok(())
+            }
+
+            fn visit_borrowed_str(&mut self, v: &'v str) -> Result<(), Error> {
+                assert_eq!("some string", v);
+                Ok(())
+            }
+
+            fn visit_char(&mut self, v: char) -> Result<(), Error> {
+                assert_eq!('n', v);
+                Ok(())
+            }
+
+            fn visit_error(&mut self, err: &(dyn crate::std::error::Error + 'static)) -> Result<(), Error> {
+                panic!("unexpected value: {}", err)
+            }
+
+            fn visit_borrowed_error(&mut self, err: &'v (dyn crate::std::error::Error + 'static)) -> Result<(), Error> {
+                panic!("unexpected value: {}", err)
+            }
+        }
+
+        unimplemented!()
+    }
+
+    #[cfg(all(feature = "sval", feature = "std"))]
+    mod sval_error {
+        use super::*;
+
+        use crate::{
+            std::{error, io, string::ToString},
+            internal::sval::v1 as sval,
+        };
+
+        #[test]
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+        fn sval1_error() {
+            let err: &(dyn error::Error + 'static) = &io::Error::from(io::ErrorKind::Other);
+            let value: &dyn sval::Value = &err;
+
+            struct VisitError<'a>(&'a (dyn error::Error + 'static));
+
+            impl<'v> Visit<'v> for VisitError<'v> {
+                fn visit_any(&mut self, v: ValueBag) -> Result<(), Error> {
+                    panic!("unexpected value: {}", v)
+                }
+
+                fn visit_i64(&mut self, v: i64) -> Result<(), Error> {
+                    panic!("unexpected value: {}", v)
+                }
+
+                fn visit_u64(&mut self, v: u64) -> Result<(), Error> {
+                    panic!("unexpected value: {}", v)
+                }
+
+                fn visit_f64(&mut self, v: f64) -> Result<(), Error> {
+                    panic!("unexpected value: {}", v)
+                }
+
+                fn visit_bool(&mut self, v: bool) -> Result<(), Error> {
+                    panic!("unexpected value: {}", v)
+                }
+
+                fn visit_str(&mut self, v: &str) -> Result<(), Error> {
+                    panic!("unexpected value: {}", v)
+                }
+
+                fn visit_borrowed_str(&mut self, v: &'v str) -> Result<(), Error> {
+                    panic!("unexpected value: {}", v)
+                }
+
+                fn visit_char(&mut self, v: char) -> Result<(), Error> {
+                    panic!("unexpected value: {}", v)
+                }
+
+                fn visit_error(&mut self, err: &(dyn crate::std::error::Error + 'static)) -> Result<(), Error> {
+                    assert_eq!(self.0.to_string(), err.to_string());
+                    Ok(())
+                }
+
+                fn visit_borrowed_error(&mut self, err: &'v (dyn crate::std::error::Error + 'static)) -> Result<(), Error> {
+                    self.visit_error(err)
+                }
+            }
+
+            // Ensure that an error captured through `sval` can be visited as an error
+            ValueBag::from_dyn_sval1(value).visit(VisitError(err)).expect("failed to visit value");
+        }
+    }
+}


### PR DESCRIPTION
For https://github.com/rust-lang/log/issues/440

This adds a simple visitor API for `ValueBag` that can be used without depending on `sval` or `serde`. It's not meant to be exhaustive, but gives us alternative methods for visiting the contents of the bag that align with the existing `ValueBag::to_*` methods.