### PR TITLE
Fix up build detection around ctor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,3 +96,7 @@ version = "0.2"
 
 [dev-dependencies.wasm-bindgen-test]
 version = "0.3"
+
+[build-dependencies.rustc]
+version = "0.9"
+package = "version_check"

--- a/build.rs
+++ b/build.rs
@@ -1,36 +1,24 @@
 use std::{env, process::Command, str};
 
 fn main() {
-    if rustc_is_nightly().unwrap_or(false) {
+    if rustc::is_feature_flaggable().unwrap_or(false) {
         println!("cargo:rustc-cfg=value_bag_capture_const_type_id");
-    } else if target_arch_is_any(&["x86_64", "aarch64"]) {
+    } else if target_arch_is_any(&["x86_64", "aarch64"]) && target_os_is_any(&["windows", "linux", "macos"]) {
         println!("cargo:rustc-cfg=value_bag_capture_ctor");
     } else {
         println!("cargo:rustc-cfg=value_bag_capture_fallback");
     }
 }
 
-fn rustc_is_nightly() -> Option<bool> {
-    let rustc = match env::var_os("RUSTC") {
-        Some(rustc) => rustc,
-        None => return None,
-    };
-
-    let output = match Command::new(rustc).arg("--version").output() {
-        Ok(output) => output,
-        Err(_) => return None,
-    };
-
-    let version = match str::from_utf8(&output.stdout) {
-        Ok(version) => version,
-        Err(_) => return None,
-    };
-
-    Some(version.contains("-nightly"))
-}
-
 fn target_arch_is_any(targets: &[&str]) -> bool {
     match env::var("CARGO_CFG_TARGET_ARCH") {
+        Ok(arch) if targets.contains(&&*arch) => true,
+        _ => false,
+    }
+}
+
+fn target_os_is_any(family: &[&str]) -> bool {
+    match env::var("CARGO_CFG_TARGET_OS") {
         Ok(arch) if targets.contains(&&*arch) => true,
         _ => false,
     }

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-use std::{env, process::Command, str};
+use std::{env, str};
 
 fn main() {
     if rustc::is_feature_flaggable().unwrap_or(false) {

--- a/build.rs
+++ b/build.rs
@@ -10,16 +10,17 @@ fn main() {
     }
 }
 
-fn target_arch_is_any(targets: &[&str]) -> bool {
-    match env::var("CARGO_CFG_TARGET_ARCH") {
-        Ok(arch) if targets.contains(&&*arch) => true,
-        _ => false,
-    }
+fn target_arch_is_any(archs: &[&str]) -> bool {
+    cargo_env_is_any("CARGO_CFG_TARGET_ARCH", archs)
 }
 
-fn target_os_is_any(family: &[&str]) -> bool {
-    match env::var("CARGO_CFG_TARGET_OS") {
-        Ok(arch) if targets.contains(&&*arch) => true,
+fn target_os_is_any(families: &[&str]) -> bool {
+    cargo_env_is_any("CARGO_CFG_TARGET_OS", families)
+}
+
+fn cargo_env_is_any(env: &str, values: &[&str]) -> bool {
+    match env::var(env) {
+        Ok(var) if values.contains(&&*var) => true,
         _ => false,
     }
 }


### PR DESCRIPTION
Closes #22
Closes #23 

Admit defeat on _how hard could it be to figure out if a compiler supports `#![feature]`_ and use the `version_check` crate.

Scope use of `#[ctor]` just to Windows, Linux, and MacOS so we don't accidentally match BSD's and iOS.