### PR TITLE
Prepare for 1.0.0-alpha.7 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "value-bag"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"

--- a/README.md
+++ b/README.md
@@ -10,20 +10,20 @@ Add the `value-bag` crate to your `Cargo.toml`:
 
 ```rust
 [dependencies.value-bag]
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 ```
 
 You'll probably also want to add a feature for either `sval` (if you're in a no-std environment) or `serde` (if you need to integrate with other code that uses `serde`):
 
 ```rust
 [dependencies.value-bag]
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 features = ["sval1"]
 ```
 
 ```rust
 [dependencies.value-bag]
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 features = ["serde1"]
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! without losing their original structure.
 
 #![cfg_attr(value_bag_capture_const_type_id, feature(const_type_id))]
-#![doc(html_root_url = "https://docs.rs/value-bag/1.0.0-alpha.6")]
+#![doc(html_root_url = "https://docs.rs/value-bag/1.0.0-alpha.7")]
 #![no_std]
 
 #[cfg(any(feature = "std", test))]


### PR DESCRIPTION
Includes:

- #24 
- #25 

I'll wait for GitHub Actions to come back up before merging this, just in case I've regressed the build script for some platforms.