### PR TITLE
Add a by-ref method as an alternative to deriving Copy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,6 +353,15 @@ pub struct ValueBag<'v> {
     inner: internal::Internal<'v>,
 }
 
+impl<'v> ValueBag<'v> {
+    /// Get a `ValueBag` from a reference to a `ValueBag`.
+    pub fn by_ref<'u>(&'u self) -> ValueBag<'u> {
+        ValueBag {
+            inner: self.inner,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
I've been avoiding deriving `Copy` on `ValueBag` just for forwards compatibility, but it's still nice to know whether you can cheaply get a `ValueBag` from a reference to one. Even in a future where there's some non-`Copy` owned data in there we'd find a way to internally borrow it.