### PR TITLE
str capturing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install miri
-        run: rustup component add miri
+        run: rustup +nightly-2021-07-06 component add miri
 
       - name: Type Id
         run: VALUE_BAG_CAPTURE_CONST_TYPE_ID=1 cargo miri test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -94,19 +94,17 @@ jobs:
   miri:
     name: Test (miri)
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - nightly-2021-07-06
+    env:
+      MIRI_TOOLCHAIN: nightly-2021-07-06
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
 
       - name: Install miri
-        run: rustup +nightly-2021-07-06 component add miri
+        run: rustup +$MIRI_TOOLCHAIN component add miri
 
       - name: Type Id
-        run: VALUE_BAG_CAPTURE_CONST_TYPE_ID=1 cargo miri test
+        run: VALUE_BAG_CAPTURE_CONST_TYPE_ID=1 cargo +$MIRI_TOOLCHAIN miri test
 
       - name: Fallback
-        run: VALUE_BAG_CAPTURE_FALLBACK=1 cargo miri test
+        run: VALUE_BAG_CAPTURE_FALLBACK=1 cargo +$MIRI_TOOLCHAIN miri test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -90,3 +90,23 @@ jobs:
       
       - name: All features
         run: wasm-pack test --node -- --all-features
+
+  miri:
+    name: Test (miri)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - nightly-2021-07-06
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install miri
+        run: rustup component add miri
+
+      - name: Type Id
+        run: VALUE_BAG_CAPTURE_CONST_TYPE_ID=1 cargo miri test
+
+      - name: Fallback
+        run: VALUE_BAG_CAPTURE_FALLBACK=1 cargo miri test

--- a/src/internal/cast/mod.rs
+++ b/src/internal/cast/mod.rs
@@ -22,17 +22,21 @@ pub(super) fn type_id<T: 'static>() -> TypeId {
     TypeId::of::<T>()
 }
 
-/// Attempt to capture a primitive from some generic value.
-///
-/// If the value is a primitive type, then cast it here, avoiding needing to erase its value
-/// This makes `ValueBag`s produced by `ValueBag::from_*` more useful
-pub(super) fn try_from_primitive<'v, T: ?Sized + 'static>(value: &'v T) -> Option<ValueBag<'v>> {
-    primitive::from_any(value).map(|primitive| ValueBag {
-        inner: Internal::Primitive { value: primitive },
-    })
-}
-
 impl<'v> ValueBag<'v> {
+    /// Try capture a raw value.
+    ///
+    /// This method will return `Some` if the value is a simple primitive
+    /// that can be captured without losing its structure. In other cases
+    /// this method will return `None`.
+    pub fn try_capture<T>(value: &'v T) -> Option<Self>
+    where
+        T: ?Sized + 'static,
+    {
+        primitive::from_any(value).map(|primitive| ValueBag {
+            inner: Internal::Primitive { value: primitive },
+        })
+    }
+
     /// Try get a `u64` from this value.
     ///
     /// This method is cheap for primitive types, but may call arbitrary
@@ -392,7 +396,24 @@ mod tests {
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::*;
 
+    use super::*;
+
+    use crate::std::string::ToString;
+
     use crate::test::IntoValueBag;
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn primitive_capture_str() {
+        let s: &str = &"short lived".to_string();
+        assert_eq!(
+            "short lived",
+            ValueBag::try_capture(s)
+                .unwrap()
+                .to_borrowed_str()
+                .expect("invalid value")
+        );
+    }
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]

--- a/src/internal/cast/mod.rs
+++ b/src/internal/cast/mod.rs
@@ -26,7 +26,7 @@ pub(super) fn type_id<T: 'static>() -> TypeId {
 ///
 /// If the value is a primitive type, then cast it here, avoiding needing to erase its value
 /// This makes `ValueBag`s produced by `ValueBag::from_*` more useful
-pub(super) fn try_from_primitive<'v, T: 'static>(value: &'v T) -> Option<ValueBag<'v>> {
+pub(super) fn try_from_primitive<'v, T: ?Sized + 'static>(value: &'v T) -> Option<ValueBag<'v>> {
     primitive::from_any(value).map(|primitive| ValueBag {
         inner: Internal::Primitive { value: primitive },
     })

--- a/src/internal/cast/primitive.rs
+++ b/src/internal/cast/primitive.rs
@@ -261,7 +261,10 @@ pub(super) fn from_any<'v, T: ?Sized + 'static>(value: &'v T) -> Option<Primitiv
         }
     }
 
-    // When we're not on `nightly` and aren't on a supported arch, we can't do capturing
+    // NOTE: The casts for unsized values (str) are dubious here. To really do this properly
+    // we need https://github.com/rust-lang/rust/issues/81513
+    // When we're not on `nightly` and aren't on a supported arch, we can't do any
+    // work at compile time for capturing
     #[cfg(any(all(value_bag_capture_ctor, miri), value_bag_capture_fallback))]
     {
         use crate::std::any::TypeId;

--- a/src/internal/cast/primitive.rs
+++ b/src/internal/cast/primitive.rs
@@ -20,7 +20,7 @@ pub(super) fn from_any<'v, T: ?Sized + 'static>(value: &'v T) -> Option<Primitiv
                 where
                     Self: 'static,
                 {
-                    const CALL: fn(&&'a Self) -> Option<Primitive<'a>> = {
+                    const CALL: fn(&'_ &'a Self) -> Option<Primitive<'a>> = {
                         $(
                             const $const_ident: TypeId = TypeId::of::<$ty>();
                             const $option_ident: TypeId = TypeId::of::<Option<$ty>>();
@@ -40,13 +40,13 @@ pub(super) fn from_any<'v, T: ?Sized + 'static>(value: &'v T) -> Option<Primitiv
                                 }),
                             )*
 
-                            STR => |v| Some(Primitive::from(*(unsafe { std::mem::transmute::<&&Self, &&str>(v) }))),
+                            STR => |v| Some(Primitive::from(unsafe { *(v as *const &Self as *const &str) })),
 
                             _ => |_| None,
                         }
                     };
 
-                    fn to_primitive(&'a self) -> Option<Primitive> {
+                    fn to_primitive(&'a self) -> Option<Primitive<'a>> {
                         (Self::CALL)(&self)
                     }
                 }

--- a/src/internal/cast/primitive.rs
+++ b/src/internal/cast/primitive.rs
@@ -86,7 +86,8 @@ pub(super) fn from_any<'v, T: ?Sized + 'static>(value: &'v T) -> Option<Primitiv
     }
 
     // When we're not on `nightly`, use the ctor crate
-    #[cfg(value_bag_capture_ctor)]
+    // For `miri` though, we can't rely on `ctor` so use the fallback
+    #[cfg(all(value_bag_capture_ctor, not(miri)))]
     {
         #![allow(unused_unsafe)]
 
@@ -263,7 +264,7 @@ pub(super) fn from_any<'v, T: ?Sized + 'static>(value: &'v T) -> Option<Primitiv
     }
 
     // When we're not on `nightly` and aren't on a supported arch, we can't do capturing
-    #[cfg(value_bag_capture_fallback)]
+    #[cfg(any(all(value_bag_capture_ctor, miri), value_bag_capture_fallback))]
     {
         use crate::std::{any::TypeId, marker::PhantomData};
 

--- a/src/internal/fmt.rs
+++ b/src/internal/fmt.rs
@@ -60,6 +60,34 @@ impl<'v> ValueBag<'v> {
         }
     }
 
+    /// Get a value from a debuggable type.
+    ///
+    /// This method will attempt to capture the given value as a well-known primitive
+    /// before resorting to using its `Debug` implementation.
+    pub fn capture_dyn_debug<'u, T>(value: &'u &'v T) -> Self
+    where
+        'u: 'v,
+        T: Debug + ?Sized + 'static,
+    {
+        cast::try_from_primitive(&**value).unwrap_or(ValueBag {
+            inner: Internal::AnonDebug { value },
+        })
+    }
+
+    /// Get a value from a displayable type.
+    ///
+    /// This method will attempt to capture the given value as a well-known primitive
+    /// before resorting to using its `Display` implementation.
+    pub fn capture_dyn_display<'u, T>(value: &'u &'v T) -> Self
+    where
+        'u: 'v,
+        T: Display + ?Sized + 'static,
+    {
+        cast::try_from_primitive(&**value).unwrap_or(ValueBag {
+            inner: Internal::AnonDisplay { value },
+        })
+    }
+
     /// Get a value from a debuggable type without capturing support.
     pub fn from_dyn_debug(value: &'v dyn Debug) -> Self {
         ValueBag {

--- a/src/internal/fmt.rs
+++ b/src/internal/fmt.rs
@@ -16,7 +16,7 @@ impl<'v> ValueBag<'v> {
     where
         T: Debug + 'static,
     {
-        cast::try_from_primitive(value).unwrap_or(ValueBag {
+        Self::try_capture(value).unwrap_or(ValueBag {
             inner: Internal::Debug {
                 value,
                 type_id: cast::type_id::<T>(),
@@ -32,7 +32,7 @@ impl<'v> ValueBag<'v> {
     where
         T: Display + 'static,
     {
-        cast::try_from_primitive(value).unwrap_or(ValueBag {
+        Self::try_capture(value).unwrap_or(ValueBag {
             inner: Internal::Display {
                 value,
                 type_id: cast::type_id::<T>(),
@@ -58,34 +58,6 @@ impl<'v> ValueBag<'v> {
         ValueBag {
             inner: Internal::AnonDisplay { value },
         }
-    }
-
-    /// Get a value from a debuggable type.
-    ///
-    /// This method will attempt to capture the given value as a well-known primitive
-    /// before resorting to using its `Debug` implementation.
-    pub fn capture_dyn_debug<'u, T>(value: &'u &'v T) -> Self
-    where
-        'u: 'v,
-        T: Debug + ?Sized + 'static,
-    {
-        cast::try_from_primitive(&**value).unwrap_or(ValueBag {
-            inner: Internal::AnonDebug { value },
-        })
-    }
-
-    /// Get a value from a displayable type.
-    ///
-    /// This method will attempt to capture the given value as a well-known primitive
-    /// before resorting to using its `Display` implementation.
-    pub fn capture_dyn_display<'u, T>(value: &'u &'v T) -> Self
-    where
-        'u: 'v,
-        T: Display + ?Sized + 'static,
-    {
-        cast::try_from_primitive(&**value).unwrap_or(ValueBag {
-            inner: Internal::AnonDisplay { value },
-        })
     }
 
     /// Get a value from a debuggable type without capturing support.

--- a/src/internal/serde/v1.rs
+++ b/src/internal/serde/v1.rs
@@ -21,7 +21,7 @@ impl<'v> ValueBag<'v> {
     where
         T: Serialize + 'static,
     {
-        cast::try_from_primitive(value).unwrap_or(ValueBag {
+        Self::try_capture(value).unwrap_or(ValueBag {
             inner: Internal::Serde1 {
                 value,
                 type_id: cast::type_id::<T>(),

--- a/src/internal/sval/v1.rs
+++ b/src/internal/sval/v1.rs
@@ -19,7 +19,7 @@ impl<'v> ValueBag<'v> {
     where
         T: Value + 'static,
     {
-        cast::try_from_primitive(value).unwrap_or(ValueBag {
+        Self::try_capture(value).unwrap_or(ValueBag {
             inner: Internal::Sval1 {
                 value,
                 type_id: cast::type_id::<T>(),
@@ -35,20 +35,6 @@ impl<'v> ValueBag<'v> {
         ValueBag {
             inner: Internal::AnonSval1 { value },
         }
-    }
-
-    /// Get a value from a structured type.
-    ///
-    /// This method will attempt to capture the given value as a well-known primitive
-    /// before resorting to using its `Value` implementation.
-    pub fn capture_dyn_sval1<'u, T>(value: &'u &'v T) -> Self
-    where
-        'u: 'v,
-        T: Value + ?Sized + 'static,
-    {
-        cast::try_from_primitive(&**value).unwrap_or(ValueBag {
-            inner: Internal::AnonSval1 { value },
-        })
     }
 
     /// Get a value from an erased structured type.

--- a/src/internal/sval/v1.rs
+++ b/src/internal/sval/v1.rs
@@ -37,6 +37,20 @@ impl<'v> ValueBag<'v> {
         }
     }
 
+    /// Get a value from a structured type.
+    ///
+    /// This method will attempt to capture the given value as a well-known primitive
+    /// before resorting to using its `Value` implementation.
+    pub fn capture_dyn_sval1<'u, T>(value: &'u &'v T) -> Self
+    where
+        'u: 'v,
+        T: Value + ?Sized + 'static,
+    {
+        cast::try_from_primitive(&**value).unwrap_or(ValueBag {
+            inner: Internal::AnonSval1 { value },
+        })
+    }
+
     /// Get a value from an erased structured type.
     pub fn from_dyn_sval1(value: &'v dyn Value) -> Self {
         ValueBag {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,15 +8,9 @@
 #![doc(html_root_url = "https://docs.rs/value-bag/1.0.0-alpha.7")]
 #![no_std]
 
-#[cfg(any(feature = "std", test))]
 #[macro_use]
 #[allow(unused_imports)]
 extern crate std;
-
-#[cfg(not(any(feature = "std", test)))]
-#[macro_use]
-#[allow(unused_imports)]
-extern crate core as std;
 
 mod error;
 pub mod fill;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,15 @@
 #![doc(html_root_url = "https://docs.rs/value-bag/1.0.0-alpha.7")]
 #![no_std]
 
+#[cfg(any(feature = "std", test))]
 #[macro_use]
 #[allow(unused_imports)]
 extern crate std;
+
+#[cfg(not(any(feature = "std", test)))]
+#[macro_use]
+#[allow(unused_imports)]
+extern crate core as std;
 
 mod error;
 pub mod fill;
@@ -355,7 +361,7 @@ mod tests {
     #[test]
     fn value_bag_size() {
         let size = mem::size_of::<ValueBag<'_>>();
-        let limit = mem::size_of::<u64>() * 4;
+        let limit = mem::size_of::<u64>() * 6;
 
         if size > limit {
             panic!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,6 @@
 //! `ValueBag`s can be captured in various ways and then formatted, inspected, and serialized
 //! without losing their original structure.
 
-#![feature(ptr_metadata)]
-
 #![cfg_attr(value_bag_capture_const_type_id, feature(const_type_id))]
 #![doc(html_root_url = "https://docs.rs/value-bag/1.0.0-alpha.7")]
 #![no_std]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 //! `ValueBag`s can be captured in various ways and then formatted, inspected, and serialized
 //! without losing their original structure.
 
+#![feature(ptr_metadata)]
+
 #![cfg_attr(value_bag_capture_const_type_id, feature(const_type_id))]
 #![doc(html_root_url = "https://docs.rs/value-bag/1.0.0-alpha.7")]
 #![no_std]


### PR DESCRIPTION
This PR reworks the way we capture primitives from values so that we can capture borrowed strings too. It isn't perfect, it's possible for multiple nested values with static lifetimes to escape detection, but it turns out our use of specialization in another project suffered from the same issues anyways.