### PR TITLE
Allow capturing Strings as strs

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -2,12 +2,6 @@
 
 use super::ValueBag;
 
-impl<'v> From<&'v str> for ValueBag<'v> {
-    fn from(value: &'v str) -> Self {
-        ValueBag::from_primitive(value)
-    }
-}
-
 macro_rules! impl_from_primitive {
     ($($into_ty:ty,)*) => {
         $(
@@ -39,6 +33,25 @@ impl_from_primitive![
     char,
     bool,
 ];
+
+impl<'v> From<&'v str> for ValueBag<'v> {
+    fn from(value: &'v str) -> Self {
+        ValueBag::from_primitive(value)
+    }
+}
+
+#[cfg(feature = "std")]
+mod std_support {
+    use super::*;
+
+    use crate::std::string::String;
+
+    impl<'v> From<&'v String> for ValueBag<'v> {
+        fn from(v: &'v String) -> ValueBag<'v> {
+            ValueBag::from_primitive(&**v)
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/internal/cast/mod.rs
+++ b/src/internal/cast/mod.rs
@@ -363,7 +363,7 @@ mod std_support {
         #[cfg(target_arch = "wasm32")]
         use wasm_bindgen_test::*;
 
-        use crate::{std::borrow::ToOwned, test::IntoValueBag};
+        use crate::{ValueBag, std::borrow::ToOwned, test::IntoValueBag};
 
         #[test]
         #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
@@ -384,7 +384,14 @@ mod std_support {
                 "a string",
                 (&*short_lived)
                     .into_value_bag()
-                    .to_str()
+                    .to_borrowed_str()
+                    .expect("invalid value")
+            );
+            assert_eq!(
+                "a string",
+                ValueBag::try_capture(&short_lived)
+                    .expect("invalid value")
+                    .to_borrowed_str()
                     .expect("invalid value")
             );
         }

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -322,3 +322,146 @@ impl<'v> From<&'v str> for Primitive<'v> {
         Primitive::Str(v)
     }
 }
+
+impl<'v> From<&'v ()> for Primitive<'v> {
+    #[inline]
+    fn from(_: &'v ()) -> Self {
+        Primitive::None
+    }
+}
+
+impl<'v> From<&'v u8> for Primitive<'v> {
+    #[inline]
+    fn from(v: &'v u8) -> Self {
+        Primitive::Unsigned(*v as u64)
+    }
+}
+
+impl<'v> From<&'v u16> for Primitive<'v> {
+    #[inline]
+    fn from(v: &'v u16) -> Self {
+        Primitive::Unsigned(*v as u64)
+    }
+}
+
+impl<'v> From<&'v u32> for Primitive<'v> {
+    #[inline]
+    fn from(v: &'v u32) -> Self {
+        Primitive::Unsigned(*v as u64)
+    }
+}
+
+impl<'v> From<&'v u64> for Primitive<'v> {
+    #[inline]
+    fn from(v: &'v u64) -> Self {
+        Primitive::Unsigned(*v)
+    }
+}
+
+impl<'v> From<&'v u128> for Primitive<'v> {
+    #[inline]
+    fn from(v: &'v u128) -> Self {
+        Primitive::BigUnsigned(*v)
+    }
+}
+
+impl<'v> From<&'v usize> for Primitive<'v> {
+    #[inline]
+    fn from(v: &'v usize) -> Self {
+        Primitive::Unsigned(*v as u64)
+    }
+}
+
+impl<'v> From<&'v i8> for Primitive<'v> {
+    #[inline]
+    fn from(v: &'v i8) -> Self {
+        Primitive::Signed(*v as i64)
+    }
+}
+
+impl<'v> From<&'v i16> for Primitive<'v> {
+    #[inline]
+    fn from(v: &'v i16) -> Self {
+        Primitive::Signed(*v as i64)
+    }
+}
+
+impl<'v> From<&'v i32> for Primitive<'v> {
+    #[inline]
+    fn from(v: &'v i32) -> Self {
+        Primitive::Signed(*v as i64)
+    }
+}
+
+impl<'v> From<&'v i64> for Primitive<'v> {
+    #[inline]
+    fn from(v: &'v i64) -> Self {
+        Primitive::Signed(*v)
+    }
+}
+
+impl<'v> From<&'v i128> for Primitive<'v> {
+    #[inline]
+    fn from(v: &'v i128) -> Self {
+        Primitive::BigSigned(*v)
+    }
+}
+
+impl<'v> From<&'v isize> for Primitive<'v> {
+    #[inline]
+    fn from(v: &'v isize) -> Self {
+        Primitive::Signed(*v as i64)
+    }
+}
+
+impl<'v> From<&'v f32> for Primitive<'v> {
+    #[inline]
+    fn from(v: &'v f32) -> Self {
+        Primitive::Float(*v as f64)
+    }
+}
+
+impl<'v> From<&'v f64> for Primitive<'v> {
+    #[inline]
+    fn from(v: &'v f64) -> Self {
+        Primitive::Float(*v)
+    }
+}
+
+impl<'v> From<&'v bool> for Primitive<'v> {
+    #[inline]
+    fn from(v: &'v bool) -> Self {
+        Primitive::Bool(*v)
+    }
+}
+
+impl<'v> From<&'v char> for Primitive<'v> {
+    #[inline]
+    fn from(v: &'v char) -> Self {
+        Primitive::Char(*v)
+    }
+}
+
+impl<'v, 'u> From<&'v &'u str> for Primitive<'v>
+where
+    'u: 'v,
+{
+    #[inline]
+    fn from(v: &'v &'u str) -> Self {
+        Primitive::Str(*v)
+    }
+}
+
+#[cfg(feature = "std")]
+mod std_support {
+    use super::*;
+
+    use std::string::String;
+
+    impl<'v> From<&'v String> for Primitive<'v> {
+        #[inline]
+        fn from(v: &'v String) -> Self {
+            Primitive::Str(&**v)
+        }
+    }
+}


### PR DESCRIPTION
So that calling `ValueBag::capture_display(&some_string).to_borrowed_str()` will return `Some` instead of `None`.