### PR TITLE
Shrink ValueBag size

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -112,7 +112,7 @@ jobs:
     name: Test (miri)
     runs-on: ubuntu-latest
     env:
-      MIRI_TOOLCHAIN: nightly-2021-07-06
+      MIRI_TOOLCHAIN: nightly-2022-02-14
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/benches/capture.rs
+++ b/benches/capture.rs
@@ -29,12 +29,14 @@ fn custom_capture_debug(b: &mut test::Bencher) {
 
 #[bench]
 fn fill_debug(b: &mut test::Bencher) {
-    b.iter(|| ValueBag::from_fill(&|slot: value_bag::fill::Slot| {
-        #[derive(Debug)]
-        struct A;
-    
-        slot.fill_debug(&A)
-    }))
+    b.iter(|| {
+        ValueBag::from_fill(&|slot: value_bag::fill::Slot| {
+            #[derive(Debug)]
+            struct A;
+
+            slot.fill_debug(&A)
+        })
+    })
 }
 
 #[bench]
@@ -51,9 +53,7 @@ fn u8_capture_debug_to_u64(b: &mut test::Bencher) {
 
 #[bench]
 fn u8_fill_to_u64(b: &mut test::Bencher) {
-    let v = ValueBag::from_fill(&|slot: value_bag::fill::Slot| {
-        slot.fill_any(1u8)
-    });
+    let v = ValueBag::from_fill(&|slot: value_bag::fill::Slot| slot.fill_any(1u8));
 
     b.iter(|| v.to_u64())
 }
@@ -69,9 +69,7 @@ fn u8_from_sval_to_u64(b: &mut test::Bencher) {
 #[bench]
 #[cfg(feature = "sval1")]
 fn u8_fill_sval_to_u64(b: &mut test::Bencher) {
-    let v = ValueBag::from_fill(&|slot: value_bag::fill::Slot| {
-        slot.fill_sval1(&1u8)
-    });
+    let v = ValueBag::from_fill(&|slot: value_bag::fill::Slot| slot.fill_sval1(&1u8));
 
     b.iter(|| v.to_u64())
 }

--- a/src/fill.rs
+++ b/src/fill.rs
@@ -40,20 +40,8 @@
 
 use crate::std::fmt;
 
-use super::internal::{Internal, InternalVisitor};
+use super::internal::InternalVisitor;
 use super::{Error, ValueBag};
-
-impl<'v> ValueBag<'v> {
-    /// Get a value from a fillable slot.
-    pub fn from_fill<T>(value: &'v T) -> Self
-    where
-        T: Fill,
-    {
-        ValueBag {
-            inner: Internal::Fill { value },
-        }
-    }
-}
 
 /// A type that requires extra work to convert into a [`ValueBag`](../struct.ValueBag.html).
 ///

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -2,27 +2,27 @@
 
 use super::ValueBag;
 
-macro_rules! impl_from_primitive {
+macro_rules! impl_from_internal {
     ($($into_ty:ty,)*) => {
         $(
             impl<'v> From<$into_ty> for ValueBag<'v> {
                 #[inline]
                 fn from(value: $into_ty) -> Self {
-                    ValueBag::from_primitive(value)
+                    ValueBag::from_internal(value)
                 }
             }
 
             impl<'a, 'v> From<&'a $into_ty> for ValueBag<'v> {
                 #[inline]
                 fn from(value: &'a $into_ty) -> Self {
-                    ValueBag::from_primitive(*value)
+                    ValueBag::from_internal(*value)
                 }
             }
         )*
     };
 }
 
-impl_from_primitive![
+impl_from_internal![
     (),
     usize,
     u8,
@@ -45,7 +45,7 @@ impl_from_primitive![
 impl<'v> From<&'v str> for ValueBag<'v> {
     #[inline]
     fn from(value: &'v str) -> Self {
-        ValueBag::from_primitive(value)
+        ValueBag::from_internal(value)
     }
 }
 
@@ -58,7 +58,7 @@ mod std_support {
     impl<'v> From<&'v String> for ValueBag<'v> {
         #[inline]
         fn from(v: &'v String) -> ValueBag<'v> {
-            ValueBag::from_primitive(&**v)
+            ValueBag::from_internal(&**v)
         }
     }
 }

--- a/src/internal/cast/mod.rs
+++ b/src/internal/cast/mod.rs
@@ -5,7 +5,6 @@
 //! They will also attempt to downcast erased types into a primitive where possible.
 
 use crate::std::{
-    any::TypeId,
     convert::{TryFrom, TryInto},
     fmt,
 };
@@ -13,14 +12,10 @@ use crate::std::{
 #[cfg(feature = "std")]
 use crate::std::{borrow::ToOwned, string::String};
 
-use super::{Internal, InternalVisitor, Primitive};
+use super::{Internal, InternalVisitor};
 use crate::{Error, ValueBag};
 
 mod primitive;
-
-pub(super) fn type_id<T: 'static>() -> TypeId {
-    TypeId::of::<T>()
-}
 
 impl<'v> ValueBag<'v> {
     /// Try capture a raw value.
@@ -32,9 +27,7 @@ impl<'v> ValueBag<'v> {
     where
         T: ?Sized + 'static,
     {
-        primitive::from_any(value).map(|primitive| ValueBag {
-            inner: Internal::Primitive { value: primitive },
-        })
+        primitive::from_any(value).map(|inner| ValueBag { inner })
     }
 
     /// Try get a `u64` from this value.
@@ -42,7 +35,7 @@ impl<'v> ValueBag<'v> {
     /// This method is cheap for primitive types, but may call arbitrary
     /// serialization implementations for complex ones.
     pub fn to_u64(&self) -> Option<u64> {
-        self.inner.cast().into_primitive().into_u64()
+        self.inner.cast().into_u64()
     }
 
     /// Try get a `i64` from this value.
@@ -50,7 +43,7 @@ impl<'v> ValueBag<'v> {
     /// This method is cheap for primitive types, but may call arbitrary
     /// serialization implementations for complex ones.
     pub fn to_i64(&self) -> Option<i64> {
-        self.inner.cast().into_primitive().into_i64()
+        self.inner.cast().into_i64()
     }
 
     /// Try get a `u128` from this value.
@@ -58,7 +51,7 @@ impl<'v> ValueBag<'v> {
     /// This method is cheap for primitive types, but may call arbitrary
     /// serialization implementations for complex ones.
     pub fn to_u128(&self) -> Option<u128> {
-        self.inner.cast().into_primitive().into_u128()
+        self.inner.cast().into_u128()
     }
 
     /// Try get a `i128` from this value.
@@ -66,7 +59,7 @@ impl<'v> ValueBag<'v> {
     /// This method is cheap for primitive types, but may call arbitrary
     /// serialization implementations for complex ones.
     pub fn to_i128(&self) -> Option<i128> {
-        self.inner.cast().into_primitive().into_i128()
+        self.inner.cast().into_i128()
     }
 
     /// Try get a `f64` from this value.
@@ -74,7 +67,7 @@ impl<'v> ValueBag<'v> {
     /// This method is cheap for primitive types, but may call arbitrary
     /// serialization implementations for complex ones.
     pub fn to_f64(&self) -> Option<f64> {
-        self.inner.cast().into_primitive().into_f64()
+        self.inner.cast().into_f64()
     }
 
     /// Try get a `bool` from this value.
@@ -82,7 +75,7 @@ impl<'v> ValueBag<'v> {
     /// This method is cheap for primitive types, but may call arbitrary
     /// serialization implementations for complex ones.
     pub fn to_bool(&self) -> Option<bool> {
-        self.inner.cast().into_primitive().into_bool()
+        self.inner.cast().into_bool()
     }
 
     /// Try get a `char` from this value.
@@ -90,7 +83,7 @@ impl<'v> ValueBag<'v> {
     /// This method is cheap for primitive types, but may call arbitrary
     /// serialization implementations for complex ones.
     pub fn to_char(&self) -> Option<char> {
-        self.inner.cast().into_primitive().into_char()
+        self.inner.cast().into_char()
     }
 
     /// Try get a `str` from this value.
@@ -98,7 +91,7 @@ impl<'v> ValueBag<'v> {
     /// This method is cheap for primitive types. It won't allocate an owned
     /// `String` if the value is a complex type.
     pub fn to_borrowed_str(&self) -> Option<&str> {
-        self.inner.cast().into_primitive().into_borrowed_str()
+        self.inner.cast().into_borrowed_str()
     }
 
     /// Check whether this value can be downcast to `T`.
@@ -108,26 +101,15 @@ impl<'v> ValueBag<'v> {
 
     /// Try downcast this value to `T`.
     pub fn downcast_ref<T: 'static>(&self) -> Option<&T> {
-        let target = TypeId::of::<T>();
         match self.inner {
-            Internal::Debug { type_id, value } if type_id == target => {
-                Some(unsafe { &*(value as *const _ as *const T) })
-            }
-            Internal::Display { type_id, value } if type_id == target => {
-                Some(unsafe { &*(value as *const _ as *const T) })
-            }
+            Internal::Debug(value) => value.as_any().downcast_ref(),
+            Internal::Display(value) => value.as_any().downcast_ref(),
             #[cfg(feature = "error")]
-            Internal::Error { type_id, value } if type_id == target => {
-                Some(unsafe { &*(value as *const _ as *const T) })
-            }
+            Internal::Error(value) => value.as_any().downcast_ref(),
             #[cfg(feature = "sval1")]
-            Internal::Sval1 { type_id, value } if type_id == target => {
-                Some(unsafe { &*(value as *const _ as *const T) })
-            }
+            Internal::Sval1(value) => value.as_any().downcast_ref(),
             #[cfg(feature = "serde1")]
-            Internal::Serde1 { type_id, value } if type_id == target => {
-                Some(unsafe { &*(value as *const _ as *const T) })
-            }
+            Internal::Serde1(value) => value.as_any().downcast_ref(),
             _ => None,
         }
     }
@@ -152,43 +134,43 @@ impl<'v> Internal<'v> {
 
             #[inline]
             fn u64(&mut self, v: u64) -> Result<(), Error> {
-                self.0 = Cast::Primitive(Primitive::Unsigned(v));
+                self.0 = Cast::Unsigned(v);
                 Ok(())
             }
 
             #[inline]
             fn i64(&mut self, v: i64) -> Result<(), Error> {
-                self.0 = Cast::Primitive(Primitive::Signed(v));
-                Ok(())
-            }
-
-            #[inline]
-            fn f64(&mut self, v: f64) -> Result<(), Error> {
-                self.0 = Cast::Primitive(Primitive::Float(v));
-                Ok(())
-            }
-
-            #[inline]
-            fn i128(&mut self, v: i128) -> Result<(), Error> {
-                self.0 = Cast::Primitive(Primitive::BigSigned(v));
+                self.0 = Cast::Signed(v);
                 Ok(())
             }
 
             #[inline]
             fn u128(&mut self, v: u128) -> Result<(), Error> {
-                self.0 = Cast::Primitive(Primitive::BigUnsigned(v));
+                self.0 = Cast::BigUnsigned(v);
+                Ok(())
+            }
+
+            #[inline]
+            fn i128(&mut self, v: i128) -> Result<(), Error> {
+                self.0 = Cast::BigSigned(v);
+                Ok(())
+            }
+
+            #[inline]
+            fn f64(&mut self, v: f64) -> Result<(), Error> {
+                self.0 = Cast::Float(v);
                 Ok(())
             }
 
             #[inline]
             fn bool(&mut self, v: bool) -> Result<(), Error> {
-                self.0 = Cast::Primitive(Primitive::Bool(v));
+                self.0 = Cast::Bool(v);
                 Ok(())
             }
 
             #[inline]
             fn char(&mut self, v: char) -> Result<(), Error> {
-                self.0 = Cast::Primitive(Primitive::Char(v));
+                self.0 = Cast::Char(v);
                 Ok(())
             }
 
@@ -207,13 +189,13 @@ impl<'v> Internal<'v> {
 
             #[inline]
             fn borrowed_str(&mut self, v: &'v str) -> Result<(), Error> {
-                self.0 = Cast::Primitive(Primitive::Str(v));
+                self.0 = Cast::Str(v);
                 Ok(())
             }
 
             #[inline]
             fn none(&mut self) -> Result<(), Error> {
-                self.0 = Cast::Primitive(Primitive::None);
+                self.0 = Cast::None;
                 Ok(())
             }
 
@@ -236,38 +218,44 @@ impl<'v> Internal<'v> {
             }
         }
 
-        if let Internal::Primitive { value } = self {
-            Cast::Primitive(value)
-        } else {
-            // If the erased value isn't a primitive then we visit it
-            let mut cast = CastVisitor(Cast::Primitive(Primitive::None));
-            let _ = self.internal_visit(&mut cast);
-            cast.0
+        match &self {
+            Internal::Signed(value) => Cast::Signed(*value),
+            Internal::Unsigned(value) => Cast::Unsigned(*value),
+            Internal::BigSigned(value) => Cast::BigSigned(*value),
+            Internal::BigUnsigned(value) => Cast::BigUnsigned(*value),
+            Internal::Float(value) => Cast::Float(*value),
+            Internal::Bool(value) => Cast::Bool(*value),
+            Internal::Char(value) => Cast::Char(*value),
+            Internal::Str(value) => Cast::Str(*value),
+            Internal::None => Cast::None,
+            other => {
+                // If the erased value isn't a primitive then we visit it
+                let mut cast = CastVisitor(Cast::None);
+                let _ = other.internal_visit(&mut cast);
+                cast.0
+            }
         }
     }
 }
 
 pub(in crate::internal) enum Cast<'v> {
-    Primitive(Primitive<'v>),
+    Signed(i64),
+    Unsigned(u64),
+    BigSigned(i128),
+    BigUnsigned(u128),
+    Float(f64),
+    Bool(bool),
+    Char(char),
+    Str(&'v str),
+    None,
     #[cfg(feature = "std")]
     String(String),
 }
 
 impl<'v> Cast<'v> {
     #[inline]
-    fn into_primitive(self) -> Primitive<'v> {
-        match self {
-            Cast::Primitive(value) => value,
-            #[cfg(feature = "std")]
-            _ => Primitive::None,
-        }
-    }
-}
-
-impl<'v> Primitive<'v> {
-    #[inline]
     fn into_borrowed_str(self) -> Option<&'v str> {
-        if let Primitive::Str(value) = self {
+        if let Cast::Str(value) = self {
             Some(value)
         } else {
             None
@@ -277,10 +265,10 @@ impl<'v> Primitive<'v> {
     #[inline]
     fn into_u64(self) -> Option<u64> {
         match self {
-            Primitive::Unsigned(value) => Some(value),
-            Primitive::BigUnsigned(value) => value.try_into().ok(),
-            Primitive::Signed(value) => value.try_into().ok(),
-            Primitive::BigSigned(value) => value.try_into().ok(),
+            Cast::Unsigned(value) => Some(value),
+            Cast::BigUnsigned(value) => value.try_into().ok(),
+            Cast::Signed(value) => value.try_into().ok(),
+            Cast::BigSigned(value) => value.try_into().ok(),
             _ => None,
         }
     }
@@ -288,10 +276,10 @@ impl<'v> Primitive<'v> {
     #[inline]
     fn into_i64(self) -> Option<i64> {
         match self {
-            Primitive::Signed(value) => Some(value),
-            Primitive::BigSigned(value) => value.try_into().ok(),
-            Primitive::Unsigned(value) => value.try_into().ok(),
-            Primitive::BigUnsigned(value) => value.try_into().ok(),
+            Cast::Signed(value) => Some(value),
+            Cast::BigSigned(value) => value.try_into().ok(),
+            Cast::Unsigned(value) => value.try_into().ok(),
+            Cast::BigUnsigned(value) => value.try_into().ok(),
             _ => None,
         }
     }
@@ -299,10 +287,10 @@ impl<'v> Primitive<'v> {
     #[inline]
     fn into_u128(self) -> Option<u128> {
         match self {
-            Primitive::BigUnsigned(value) => Some(value),
-            Primitive::Unsigned(value) => Some(value.into()),
-            Primitive::Signed(value) => value.try_into().ok(),
-            Primitive::BigSigned(value) => value.try_into().ok(),
+            Cast::BigUnsigned(value) => Some(value),
+            Cast::Unsigned(value) => Some(value.into()),
+            Cast::Signed(value) => value.try_into().ok(),
+            Cast::BigSigned(value) => value.try_into().ok(),
             _ => None,
         }
     }
@@ -310,10 +298,10 @@ impl<'v> Primitive<'v> {
     #[inline]
     fn into_i128(self) -> Option<i128> {
         match self {
-            Primitive::BigSigned(value) => Some(value),
-            Primitive::Signed(value) => Some(value.into()),
-            Primitive::Unsigned(value) => value.try_into().ok(),
-            Primitive::BigUnsigned(value) => value.try_into().ok(),
+            Cast::BigSigned(value) => Some(value),
+            Cast::Signed(value) => Some(value.into()),
+            Cast::Unsigned(value) => value.try_into().ok(),
+            Cast::BigUnsigned(value) => value.try_into().ok(),
             _ => None,
         }
     }
@@ -321,17 +309,17 @@ impl<'v> Primitive<'v> {
     #[inline]
     fn into_f64(self) -> Option<f64> {
         match self {
-            Primitive::Float(value) => Some(value),
-            Primitive::Unsigned(value) => u32::try_from(value)
+            Cast::Float(value) => Some(value),
+            Cast::Unsigned(value) => u32::try_from(value)
                 .ok()
                 .and_then(|value| value.try_into().ok()),
-            Primitive::Signed(value) => i32::try_from(value)
+            Cast::Signed(value) => i32::try_from(value)
                 .ok()
                 .and_then(|value| value.try_into().ok()),
-            Primitive::BigUnsigned(value) => u32::try_from(value)
+            Cast::BigUnsigned(value) => u32::try_from(value)
                 .ok()
                 .and_then(|value| value.try_into().ok()),
-            Primitive::BigSigned(value) => i32::try_from(value)
+            Cast::BigSigned(value) => i32::try_from(value)
                 .ok()
                 .and_then(|value| value.try_into().ok()),
             _ => None,
@@ -340,7 +328,7 @@ impl<'v> Primitive<'v> {
 
     #[inline]
     fn into_char(self) -> Option<char> {
-        if let Primitive::Char(value) = self {
+        if let Cast::Char(value) = self {
             Some(value)
         } else {
             None
@@ -349,7 +337,7 @@ impl<'v> Primitive<'v> {
 
     #[inline]
     fn into_bool(self) -> Option<bool> {
-        if let Primitive::Bool(value) = self {
+        if let Cast::Bool(value) = self {
             Some(value)
         } else {
             None
@@ -379,7 +367,7 @@ mod std_support {
         #[inline]
         pub(super) fn into_str(self) -> Option<Cow<'v, str>> {
             match self {
-                Cast::Primitive(Primitive::Str(value)) => Some(value.into()),
+                Cast::Str(value) => Some(value.into()),
                 Cast::String(value) => Some(value.into()),
                 _ => None,
             }

--- a/src/internal/cast/primitive.rs
+++ b/src/internal/cast/primitive.rs
@@ -269,6 +269,7 @@ pub(super) fn from_any<'v, T: ?Sized + 'static>(value: &'v T) -> Option<Internal
                 bool,
                 &'static str,
                 // We deal with `str` separately because it's unsized
+                // str,
                 #[cfg(feature = "std")]
                 String,
             ];
@@ -360,6 +361,7 @@ pub(super) fn from_any<'v, T: ?Sized + 'static>(value: &'v T) -> Option<Internal
             bool,
             &'static str,
             // We deal with `str` separately because it's unsized
+            // str,
             #[cfg(feature = "std")]
             String,
         ];

--- a/src/internal/cast/primitive.rs
+++ b/src/internal/cast/primitive.rs
@@ -1,6 +1,6 @@
 /*
 This module generates code to try efficiently convert some arbitrary `T: 'static` into
-a `Primitive`.
+a `Internal`.
 
 In the future when `min_specialization` is stabilized we could use it instead and avoid needing
 the `'static` bound altogether.
@@ -9,24 +9,24 @@ the `'static` bound altogether.
 #[cfg(feature = "std")]
 use crate::std::string::String;
 
-use crate::internal::Primitive;
+use crate::internal::Internal;
 
-pub(super) fn from_any<'v, T: ?Sized + 'static>(value: &'v T) -> Option<Primitive<'v>> {
+pub(super) fn from_any<'v, T: ?Sized + 'static>(value: &'v T) -> Option<Internal<'v>> {
     // When we're on `nightly`, we can use const type ids
     #[cfg(value_bag_capture_const_type_id)]
     {
         use crate::std::any::TypeId;
 
-        macro_rules! to_primitive {
+        macro_rules! to_internal {
             ($(
                 $(#[cfg($($cfg:tt)*)])*
                 $ty:ty : ($const_ident:ident, $option_ident:ident),
             )*) => {
-                trait ToPrimitive<'a>
+                trait ToInternal<'a>
                 where
                     Self: 'static,
                 {
-                    const CALL: fn(&'_ &'a Self) -> Option<Primitive<'a>> = {
+                    const CALL: fn(&'_ &'a Self) -> Option<Internal<'a>> = {
                         $(
                             $(#[cfg($($cfg)*)])*
                             const $const_ident: TypeId = TypeId::of::<$ty>();
@@ -40,35 +40,35 @@ pub(super) fn from_any<'v, T: ?Sized + 'static>(value: &'v T) -> Option<Primitiv
                         match TypeId::of::<Self>() {
                             $(
                                 $(#[cfg($($cfg)*)])*
-                                $const_ident => |v| Some(Primitive::from(unsafe { &*(*v as *const Self as *const $ty) })),
+                                $const_ident => |v| Some(Internal::from(unsafe { &*(*v as *const Self as *const $ty) })),
 
                                 $(#[cfg($($cfg)*)])*
                                 $option_ident => |v| Some({
                                     let v = unsafe { &*(*v as *const Self as *const Option<$ty>) };
                                     match v {
-                                        Some(v) => Primitive::from(v),
-                                        None => Primitive::None,
+                                        Some(v) => Internal::from(v),
+                                        None => Internal::None,
                                     }
                                 }),
                             )*
 
-                            STR => |v| Some(Primitive::from(unsafe { &**(v as *const &'a Self as *const &'a str) })),
+                            STR => |v| Some(Internal::from(unsafe { &**(v as *const &'a Self as *const &'a str) })),
 
                             _ => |_| None,
                         }
                     };
 
-                    fn to_primitive(&'a self) -> Option<Primitive<'a>> {
+                    fn to_internal(&'a self) -> Option<Internal<'a>> {
                         (Self::CALL)(&self)
                     }
                 }
 
-                impl<'a, T: ?Sized + 'static> ToPrimitive<'a> for T {}
+                impl<'a, T: ?Sized + 'static> ToInternal<'a> for T {}
             }
         }
 
         // NOTE: The types here *must* match the ones used below when `const_type_id` is not available
-        to_primitive![
+        to_internal![
             usize: (USIZE, OPTION_USIZE),
             u8: (U8, OPTION_U8),
             u16: (U16, OPTION_U16),
@@ -96,7 +96,7 @@ pub(super) fn from_any<'v, T: ?Sized + 'static>(value: &'v T) -> Option<Primitiv
             String: (STRING, OPTION_STRING),
         ];
 
-        value.to_primitive()
+        value.to_internal()
     }
 
     // When we're not on `nightly`, use the ctor crate
@@ -207,8 +207,8 @@ pub(super) fn from_any<'v, T: ?Sized + 'static>(value: &'v T) -> Option<Primitiv
                             // SAFETY: We verify the value is str before casting
                             let v = *(v.0 as *const &'_ str);
 
-                            Primitive::from(v)
-                        }) as for<'a> fn(VoidRef<'a>) -> Primitive<'a>
+                            Internal::from(v)
+                        }) as for<'a> fn(VoidRef<'a>) -> Internal<'a>
                     ),
                     $(
                         $(#[cfg($($cfg)*)])*
@@ -218,8 +218,8 @@ pub(super) fn from_any<'v, T: ?Sized + 'static>(value: &'v T) -> Option<Primitiv
                                 // SAFETY: We verify the value is $ty before casting
                                 let v = *(v.0 as *const &'_ $ty);
 
-                                Primitive::from(v)
-                            }) as for<'a> fn(VoidRef<'a>) -> Primitive<'a>
+                                Internal::from(v)
+                            }) as for<'a> fn(VoidRef<'a>) -> Internal<'a>
                         ),
                     )*
                     $(
@@ -231,11 +231,11 @@ pub(super) fn from_any<'v, T: ?Sized + 'static>(value: &'v T) -> Option<Primitiv
                                 let v = *(v.0 as *const &'_ Option<$ty>);
 
                                 if let Some(v) = v {
-                                    Primitive::from(v)
+                                    Internal::from(v)
                                 } else {
-                                    Primitive::None
+                                    Internal::None
                                 }
-                            }) as for<'a> fn(VoidRef<'a>) -> Primitive<'a>
+                            }) as for<'a> fn(VoidRef<'a>) -> Internal<'a>
                         ),
                     )*
                 ]
@@ -248,7 +248,7 @@ pub(super) fn from_any<'v, T: ?Sized + 'static>(value: &'v T) -> Option<Primitiv
         const LEN: usize = 37;
 
         #[ctor]
-        static TYPE_IDS: [(TypeId, for<'a> fn(VoidRef<'a>) -> Primitive<'a>); LEN] = {
+        static TYPE_IDS: [(TypeId, for<'a> fn(VoidRef<'a>) -> Internal<'a>); LEN] = {
             // NOTE: The types here *must* match the ones used above when `const_type_id` is available
             let mut type_ids = type_ids![
                 usize,
@@ -310,7 +310,7 @@ pub(super) fn from_any<'v, T: ?Sized + 'static>(value: &'v T) -> Option<Primitiv
                         // SAFETY: We verify the value is str before casting
                         let v = unsafe { *(v.0 as *const &'_ str) };
 
-                        return Some(Primitive::from(v));
+                        return Some(Internal::from(v));
                     }
 
                     $(
@@ -319,7 +319,7 @@ pub(super) fn from_any<'v, T: ?Sized + 'static>(value: &'v T) -> Option<Primitiv
                             // SAFETY: We verify the value is $ty before casting
                             let v = unsafe { *(v.0 as *const &'_ $ty) };
 
-                            return Some(Primitive::from(v));
+                            return Some(Internal::from(v));
                         }
                     )*
                     $(
@@ -329,9 +329,9 @@ pub(super) fn from_any<'v, T: ?Sized + 'static>(value: &'v T) -> Option<Primitiv
                             let v = unsafe { *(v.0 as *const &'_ Option<$ty>) };
 
                             if let Some(v) = v {
-                                return Some(Primitive::from(v));
+                                return Some(Internal::from(v));
                             } else {
-                                return Some(Primitive::None);
+                                return Some(Internal::None);
                             }
                         }
                     )*

--- a/src/internal/error.rs
+++ b/src/internal/error.rs
@@ -1,6 +1,10 @@
-use crate::{fill::Slot, std::error, ValueBag};
+use crate::{
+    fill::Slot,
+    std::{any::Any, error},
+    ValueBag,
+};
 
-use super::{cast, Internal};
+use super::Internal;
 
 impl<'v> ValueBag<'v> {
     /// Get a value from an error.
@@ -9,10 +13,7 @@ impl<'v> ValueBag<'v> {
         T: error::Error + 'static,
     {
         ValueBag {
-            inner: Internal::Error {
-                value,
-                type_id: cast::type_id::<T>(),
-            },
+            inner: Internal::Error(value),
         }
     }
 
@@ -20,7 +21,7 @@ impl<'v> ValueBag<'v> {
     #[inline]
     pub fn from_dyn_error(value: &'v (dyn error::Error + 'static)) -> Self {
         ValueBag {
-            inner: Internal::AnonError { value },
+            inner: Internal::AnonError(value),
         }
     }
 
@@ -28,10 +29,27 @@ impl<'v> ValueBag<'v> {
     #[inline]
     pub fn to_borrowed_error(&self) -> Option<&(dyn Error + 'static)> {
         match self.inner {
-            Internal::Error { value, .. } => Some(value),
-            Internal::AnonError { value } => Some(value),
+            Internal::Error(value) => Some(value.as_super()),
+            Internal::AnonError(value) => Some(value),
             _ => None,
         }
+    }
+}
+
+#[cfg(feature = "error")]
+pub(crate) trait DowncastError {
+    fn as_any(&self) -> &dyn Any;
+    fn as_super(&self) -> &(dyn error::Error + 'static);
+}
+
+#[cfg(feature = "error")]
+impl<T: error::Error + 'static> DowncastError for T {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_super(&self) -> &(dyn error::Error + 'static) {
+        self
     }
 }
 

--- a/src/internal/fill.rs
+++ b/src/internal/fill.rs
@@ -1,0 +1,14 @@
+use super::Internal;
+use crate::{fill::Fill, ValueBag};
+
+impl<'v> ValueBag<'v> {
+    /// Get a value from a fillable slot.
+    pub fn from_fill<T>(value: &'v T) -> Self
+    where
+        T: Fill,
+    {
+        ValueBag {
+            inner: Internal::Fill(value),
+        }
+    }
+}

--- a/src/internal/sval/v1.rs
+++ b/src/internal/sval/v1.rs
@@ -5,8 +5,8 @@
 
 use crate::{
     fill::Slot,
-    internal::{cast, Internal, InternalVisitor},
-    std::fmt,
+    internal::{Internal, InternalVisitor},
+    std::{any::Any, fmt},
     Error, ValueBag,
 };
 
@@ -20,10 +20,7 @@ impl<'v> ValueBag<'v> {
         T: Value + 'static,
     {
         Self::try_capture(value).unwrap_or(ValueBag {
-            inner: Internal::Sval1 {
-                value,
-                type_id: cast::type_id::<T>(),
-            },
+            inner: Internal::Sval1(value),
         })
     }
 
@@ -33,7 +30,7 @@ impl<'v> ValueBag<'v> {
         T: Value,
     {
         ValueBag {
-            inner: Internal::AnonSval1 { value },
+            inner: Internal::AnonSval1(value),
         }
     }
 
@@ -41,8 +38,23 @@ impl<'v> ValueBag<'v> {
     #[inline]
     pub fn from_dyn_sval1(value: &'v dyn Value) -> Self {
         ValueBag {
-            inner: Internal::AnonSval1 { value },
+            inner: Internal::AnonSval1(value),
         }
+    }
+}
+
+pub(crate) trait DowncastValue {
+    fn as_any(&self) -> &dyn Any;
+    fn as_super(&self) -> &dyn Value;
+}
+
+impl<T: Value + 'static> DowncastValue for T {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_super(&self) -> &dyn Value {
+        self
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,14 +369,13 @@ mod tests {
     #[test]
     fn value_bag_size() {
         let size = mem::size_of::<ValueBag<'_>>();
-        let limit = mem::size_of::<u64>() * 6;
+        let limit = mem::size_of::<u64>() * 4;
 
         if size > limit {
             panic!(
-                "`ValueBag` size ({} bytes) is too large (expected up to {} bytes)\n`Primitive`: {} bytes\n`(`&dyn` + `TypeId`): {} bytes",
+                "`ValueBag` size ({} bytes) is too large (expected up to {} bytes)\n`(`&dyn` + `TypeId`): {} bytes",
                 size,
                 limit,
-                mem::size_of::<internal::Primitive<'_>>(),
                 mem::size_of::<(&dyn internal::fmt::Debug, crate::std::any::TypeId)>(),
             );
         }


### PR DESCRIPTION
By inlining the rest of our `enum` members and avoiding the need to store `TypeId`s directly, we shave the size of `ValueBag`s down from `48` to `32` bytes each. There would be more to save by removing 128bit numbers (that drops the size down to `24` bytes), but I don't think I'll pursue that at this stage. One option could be to use `&'v u128`, which would prevent them from being directly converted, but still supported in some way.