### PR TITLE
Reduce ValueBag size to 24 bytes

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -29,13 +29,11 @@ impl_from_internal![
     u16,
     u32,
     u64,
-    u128,
     isize,
     i8,
     i16,
     i32,
     i64,
-    i128,
     f32,
     f64,
     char,
@@ -45,6 +43,20 @@ impl_from_internal![
 impl<'v> From<&'v str> for ValueBag<'v> {
     #[inline]
     fn from(value: &'v str) -> Self {
+        ValueBag::from_internal(value)
+    }
+}
+
+impl<'v> From<&'v u128> for ValueBag<'v> {
+    #[inline]
+    fn from(value: &'v u128) -> Self {
+        ValueBag::from_internal(value)
+    }
+}
+
+impl<'v> From<&'v i128> for ValueBag<'v> {
+    #[inline]
+    fn from(value: &'v i128) -> Self {
         ValueBag::from_internal(value)
     }
 }

--- a/src/internal/cast/mod.rs
+++ b/src/internal/cast/mod.rs
@@ -145,14 +145,14 @@ impl<'v> Internal<'v> {
             }
 
             #[inline]
-            fn u128(&mut self, v: u128) -> Result<(), Error> {
-                self.0 = Cast::BigUnsigned(v);
+            fn u128(&mut self, v: &u128) -> Result<(), Error> {
+                self.0 = Cast::BigUnsigned(*v);
                 Ok(())
             }
 
             #[inline]
-            fn i128(&mut self, v: i128) -> Result<(), Error> {
-                self.0 = Cast::BigSigned(v);
+            fn i128(&mut self, v: &i128) -> Result<(), Error> {
+                self.0 = Cast::BigSigned(*v);
                 Ok(())
             }
 
@@ -221,8 +221,8 @@ impl<'v> Internal<'v> {
         match &self {
             Internal::Signed(value) => Cast::Signed(*value),
             Internal::Unsigned(value) => Cast::Unsigned(*value),
-            Internal::BigSigned(value) => Cast::BigSigned(*value),
-            Internal::BigUnsigned(value) => Cast::BigUnsigned(*value),
+            Internal::BigSigned(value) => Cast::BigSigned(**value),
+            Internal::BigUnsigned(value) => Cast::BigUnsigned(**value),
             Internal::Float(value) => Cast::Float(*value),
             Internal::Bool(value) => Cast::Bool(*value),
             Internal::Char(value) => Cast::Char(*value),

--- a/src/internal/fmt.rs
+++ b/src/internal/fmt.rs
@@ -158,13 +158,13 @@ impl<'v> Debug for ValueBag<'v> {
                 Ok(())
             }
 
-            fn u128(&mut self, v: u128) -> Result<(), Error> {
+            fn u128(&mut self, v: &u128) -> Result<(), Error> {
                 Debug::fmt(&v, self.0)?;
 
                 Ok(())
             }
 
-            fn i128(&mut self, v: i128) -> Result<(), Error> {
+            fn i128(&mut self, v: &i128) -> Result<(), Error> {
                 Debug::fmt(&v, self.0)?;
 
                 Ok(())
@@ -255,13 +255,13 @@ impl<'v> Display for ValueBag<'v> {
                 Ok(())
             }
 
-            fn u128(&mut self, v: u128) -> Result<(), Error> {
+            fn u128(&mut self, v: &u128) -> Result<(), Error> {
                 Display::fmt(&v, self.0)?;
 
                 Ok(())
             }
 
-            fn i128(&mut self, v: i128) -> Result<(), Error> {
+            fn i128(&mut self, v: &i128) -> Result<(), Error> {
                 Display::fmt(&v, self.0)?;
 
                 Ok(())

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -29,9 +29,9 @@ pub(super) enum Internal<'v> {
     /// An unsigned integer.
     Unsigned(u64),
     /// An extra large signed integer.
-    BigSigned(i128),
+    BigSigned(&'v i128),
     /// An extra large unsigned integer.
-    BigUnsigned(u128),
+    BigUnsigned(&'v u128),
     /// A floating point number.
     Float(f64),
     /// A boolean value.
@@ -146,8 +146,14 @@ pub(super) trait InternalVisitor<'v> {
 
     fn u64(&mut self, v: u64) -> Result<(), Error>;
     fn i64(&mut self, v: i64) -> Result<(), Error>;
-    fn u128(&mut self, v: u128) -> Result<(), Error>;
-    fn i128(&mut self, v: i128) -> Result<(), Error>;
+    fn u128(&mut self, v: &u128) -> Result<(), Error>;
+    fn borrowed_u128(&mut self, v: &'v u128) -> Result<(), Error> {
+        self.u128(v)
+    }
+    fn i128(&mut self, v: &i128) -> Result<(), Error>;
+    fn borrowed_i128(&mut self, v: &'v i128) -> Result<(), Error> {
+        self.i128(v)
+    }
     fn f64(&mut self, v: f64) -> Result<(), Error>;
     fn bool(&mut self, v: bool) -> Result<(), Error>;
     fn char(&mut self, v: char) -> Result<(), Error>;
@@ -208,13 +214,6 @@ impl<'v> From<u64> for Internal<'v> {
     }
 }
 
-impl<'v> From<u128> for Internal<'v> {
-    #[inline]
-    fn from(v: u128) -> Self {
-        Internal::BigUnsigned(v)
-    }
-}
-
 impl<'v> From<usize> for Internal<'v> {
     #[inline]
     fn from(v: usize) -> Self {
@@ -247,13 +246,6 @@ impl<'v> From<i64> for Internal<'v> {
     #[inline]
     fn from(v: i64) -> Self {
         Internal::Signed(v)
-    }
-}
-
-impl<'v> From<i128> for Internal<'v> {
-    #[inline]
-    fn from(v: i128) -> Self {
-        Internal::BigSigned(v)
     }
 }
 
@@ -337,7 +329,7 @@ impl<'v> From<&'v u64> for Internal<'v> {
 impl<'v> From<&'v u128> for Internal<'v> {
     #[inline]
     fn from(v: &'v u128) -> Self {
-        Internal::BigUnsigned(*v)
+        Internal::BigUnsigned(v)
     }
 }
 
@@ -379,7 +371,7 @@ impl<'v> From<&'v i64> for Internal<'v> {
 impl<'v> From<&'v i128> for Internal<'v> {
     #[inline]
     fn from(v: &'v i128) -> Self {
-        Internal::BigSigned(*v)
+        Internal::BigSigned(v)
     }
 }
 

--- a/src/internal/serde/v1.rs
+++ b/src/internal/serde/v1.rs
@@ -133,13 +133,13 @@ impl<'v> serde1_lib::Serialize for ValueBag<'v> {
                 self.result()
             }
 
-            fn u128(&mut self, v: u128) -> Result<(), Error> {
-                self.result = Some(self.serializer()?.serialize_u128(v));
+            fn u128(&mut self, v: &u128) -> Result<(), Error> {
+                self.result = Some(self.serializer()?.serialize_u128(*v));
                 self.result()
             }
 
-            fn i128(&mut self, v: i128) -> Result<(), Error> {
-                self.result = Some(self.serializer()?.serialize_i128(v));
+            fn i128(&mut self, v: &i128) -> Result<(), Error> {
+                self.result = Some(self.serializer()?.serialize_i128(*v));
                 self.result()
             }
 
@@ -249,7 +249,7 @@ pub(crate) fn internal_visit<'v>(
         }
 
         fn serialize_u128(self, v: u128) -> Result<Self::Ok, Self::Error> {
-            self.0.u128(v).map_err(|_| Unsupported)
+            self.0.u128(&v).map_err(|_| Unsupported)
         }
 
         fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
@@ -269,7 +269,7 @@ pub(crate) fn internal_visit<'v>(
         }
 
         fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
-            self.0.i128(v).map_err(|_| Unsupported)
+            self.0.i128(&v).map_err(|_| Unsupported)
         }
 
         fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {

--- a/src/internal/sval/v1.rs
+++ b/src/internal/sval/v1.rs
@@ -96,12 +96,12 @@ impl<'v> Value for ValueBag<'v> {
                 self.0.i64(v).map_err(Error::from_sval1)
             }
 
-            fn u128(&mut self, v: u128) -> Result<(), Error> {
-                self.0.u128(v).map_err(Error::from_sval1)
+            fn u128(&mut self, v: &u128) -> Result<(), Error> {
+                self.0.u128(*v).map_err(Error::from_sval1)
             }
 
-            fn i128(&mut self, v: i128) -> Result<(), Error> {
-                self.0.i128(v).map_err(Error::from_sval1)
+            fn i128(&mut self, v: &i128) -> Result<(), Error> {
+                self.0.i128(*v).map_err(Error::from_sval1)
             }
 
             fn f64(&mut self, v: f64) -> Result<(), Error> {
@@ -176,8 +176,9 @@ pub(crate) fn internal_visit<'v>(
             Ok(())
         }
 
-        fn u64(&mut self, v: u64) -> sval1_lib::stream::Result {
-            self.0.u64(v).map_err(Error::into_sval1)?;
+        #[cfg(feature = "error")]
+        fn error(&mut self, v: sval1_lib::stream::Source) -> sval1_lib::stream::Result {
+            self.0.error(v.get()).map_err(Error::into_sval1)?;
             Ok(())
         }
 
@@ -186,13 +187,18 @@ pub(crate) fn internal_visit<'v>(
             Ok(())
         }
 
-        fn u128(&mut self, v: u128) -> sval1_lib::stream::Result {
-            self.0.u128(v).map_err(Error::into_sval1)?;
+        fn u64(&mut self, v: u64) -> sval1_lib::stream::Result {
+            self.0.u64(v).map_err(Error::into_sval1)?;
             Ok(())
         }
 
         fn i128(&mut self, v: i128) -> sval1_lib::stream::Result {
-            self.0.i128(v).map_err(Error::into_sval1)?;
+            self.0.i128(&v).map_err(Error::into_sval1)?;
+            Ok(())
+        }
+
+        fn u128(&mut self, v: u128) -> sval1_lib::stream::Result {
+            self.0.u128(&v).map_err(Error::into_sval1)?;
             Ok(())
         }
 
@@ -201,24 +207,18 @@ pub(crate) fn internal_visit<'v>(
             Ok(())
         }
 
-        fn char(&mut self, v: char) -> sval1_lib::stream::Result {
-            self.0.char(v).map_err(Error::into_sval1)?;
-            Ok(())
-        }
-
         fn bool(&mut self, v: bool) -> sval1_lib::stream::Result {
             self.0.bool(v).map_err(Error::into_sval1)?;
             Ok(())
         }
 
-        fn str(&mut self, s: &str) -> sval1_lib::stream::Result {
-            self.0.str(s).map_err(Error::into_sval1)?;
+        fn char(&mut self, v: char) -> sval1_lib::stream::Result {
+            self.0.char(v).map_err(Error::into_sval1)?;
             Ok(())
         }
 
-        #[cfg(feature = "error")]
-        fn error(&mut self, v: sval1_lib::stream::Source) -> sval1_lib::stream::Result {
-            self.0.error(v.get()).map_err(Error::into_sval1)?;
+        fn str(&mut self, s: &str) -> sval1_lib::stream::Result {
+            self.0.str(s).map_err(Error::into_sval1)?;
             Ok(())
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,7 +369,7 @@ mod tests {
     #[test]
     fn value_bag_size() {
         let size = mem::size_of::<ValueBag<'_>>();
-        let limit = mem::size_of::<u64>() * 4;
+        let limit = mem::size_of::<u64>() * 3;
 
         if size > limit {
             panic!(

--- a/src/test.rs
+++ b/src/test.rs
@@ -94,13 +94,13 @@ impl<'v> ValueBag<'v> {
                 Ok(())
             }
 
-            fn u128(&mut self, v: u128) -> Result<(), Error> {
-                self.0 = Some(Token::U128(v));
+            fn u128(&mut self, v: &u128) -> Result<(), Error> {
+                self.0 = Some(Token::U128(*v));
                 Ok(())
             }
 
-            fn i128(&mut self, v: i128) -> Result<(), Error> {
-                self.0 = Some(Token::I128(v));
+            fn i128(&mut self, v: &i128) -> Result<(), Error> {
+                self.0 = Some(Token::I128(*v));
                 Ok(())
             }
 

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -95,7 +95,7 @@ pub trait Visit<'v> {
     #[inline]
     #[cfg(not(test))]
     fn visit_u128(&mut self, value: u128) -> Result<(), Error> {
-        self.visit_any(value.into())
+        self.visit_any((&value).into())
     }
     #[cfg(test)]
     fn visit_u128(&mut self, value: u128) -> Result<(), Error>;
@@ -104,7 +104,7 @@ pub trait Visit<'v> {
     #[inline]
     #[cfg(not(test))]
     fn visit_i128(&mut self, value: i128) -> Result<(), Error> {
-        self.visit_any(value.into())
+        self.visit_any((&value).into())
     }
     #[cfg(test)]
     fn visit_i128(&mut self, value: i128) -> Result<(), Error>;
@@ -283,12 +283,12 @@ impl<'v> ValueBag<'v> {
                 self.0.visit_i64(v)
             }
 
-            fn u128(&mut self, v: u128) -> Result<(), Error> {
-                self.0.visit_u128(v)
+            fn u128(&mut self, v: &u128) -> Result<(), Error> {
+                self.0.visit_u128(*v)
             }
 
-            fn i128(&mut self, v: i128) -> Result<(), Error> {
-                self.0.visit_i128(v)
+            fn i128(&mut self, v: &i128) -> Result<(), Error> {
+                self.0.visit_i128(*v)
             }
 
             fn f64(&mut self, v: f64) -> Result<(), Error> {
@@ -356,10 +356,10 @@ mod tests {
         ValueBag::from(-42i64)
             .visit(TestVisit)
             .expect("failed to visit value");
-        ValueBag::from(42u128)
+        ValueBag::from(&42u128)
             .visit(TestVisit)
             .expect("failed to visit value");
-        ValueBag::from(-42i128)
+        ValueBag::from(&-42i128)
             .visit(TestVisit)
             .expect("failed to visit value");
         ValueBag::from(11f64)


### PR DESCRIPTION
Instead of storing 128bit numbers directly, we store references to them. This means you can't convert a `u128` or `i128` to a `ValueBag` directly, but can still convert references.