### PR TITLE
Update to sval 2.x

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -93,7 +93,7 @@ jobs:
           override: true
 
       - name: Benches
-        run: cargo bench --no-run --features "error sval1 serde1"
+        run: cargo bench --no-run --features "error sval2 serde1"
 
   wasm:
     name: Test (wasm)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -118,7 +118,7 @@ jobs:
     name: Test (miri)
     runs-on: ubuntu-latest
     env:
-      MIRI_TOOLCHAIN: nightly-2022-02-14
+      MIRI_TOOLCHAIN: nightly-2023-03-26
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "value-bag"
 version = "1.0.0-alpha.9"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/value-bag"
 description = "Anonymous structured values"
@@ -31,12 +31,13 @@ std = [
     "value-bag-serde1?/std",
 ]
 
+# Assume an allocator
 alloc = [
     "value-bag-sval2?/alloc",
     "value-bag-serde1?/alloc",
 ]
 
-# Add support for sval
+# Add support for `sval`
 sval = ["sval2"]
 sval2 = [
     "value-bag-sval2",
@@ -55,14 +56,16 @@ error = [
     "std",
 ]
 
-# Add support for converting value bags into test tokens
+# Add support for testing the contents of a value bag
 test = ["std"]
 
 [dependencies.value-bag-sval2]
+version = "1.0.0-alpha.9"
 path = "meta/sval2"
 optional = true
 
 [dependencies.value-bag-serde1]
+version = "1.0.0-alpha.9"
 path = "meta/serde1"
 optional = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,27 +18,36 @@ build = "build.rs"
 [package.metadata.docs.rs]
 features = ["std", "error", "sval", "serde", "test"]
 
+[workspace]
+members = [
+    "meta/serde1",
+    "meta/sval2",
+]
+
 [features]
 # Use the standard library
 std = [
-    "sval1_lib?/std",
-    "serde1_lib?/std",
+    "value-bag-sval2?/std",
+    "value-bag-serde1?/std",
+]
+
+alloc = [
+    "value-bag-sval2?/alloc",
+    "value-bag-serde1?/alloc",
 ]
 
 # Add support for sval
-sval = ["sval1"]
-sval1 = [
-    "sval1_lib",
+sval = ["sval2"]
+sval2 = [
+    "value-bag-sval2",
 ]
 
 # Add support for `serde`
 serde = ["serde1"]
 serde1 = [
-    "serde1_lib",
-    "erased-serde1_lib/alloc",
-    "serde1_fmt_lib",
-    "sval1_lib?/serde1",
-    "sval1_lib?/alloc",
+    "alloc",
+    "value-bag-serde1",
+    "value-bag-sval2?/serde1",
 ]
 
 # Add support for `std::error`
@@ -49,51 +58,25 @@ error = [
 # Add support for converting value bags into test tokens
 test = ["std"]
 
-[dependencies.sval1_lib]
-version = "=1.0.0-alpha.5"
+[dependencies.value-bag-sval2]
+path = "meta/sval2"
 optional = true
-default-features = false
-features = ["fmt"]
-package = "sval"
 
-[dependencies.serde1_lib]
-version = "1"
-default-features = false
+[dependencies.value-bag-serde1]
+path = "meta/serde1"
 optional = true
-package = "serde"
-
-[dependencies.serde1_fmt_lib]
-version = "1"
-optional = true
-package = "serde_fmt"
-
-[dependencies.erased-serde1_lib]
-version = "0.3"
-default-features = false
-optional = true
-package = "erased-serde"
 
 # Only needed on non-nightly compilers
 [dependencies.ctor]
 version = "0.1"
 
-[dev-dependencies.sval1_lib]
-version = "=1.0.0-alpha.5"
-features = ["test"]
-package = "sval"
+[dev-dependencies.value-bag-sval2]
+path = "meta/sval2"
+features = ["test", "json"]
 
-[dev-dependencies.serde1_test]
-version = "1"
-package = "serde_test"
-
-[dev-dependencies.sval1_json]
-version = "=1.0.0-alpha.5"
-features = ["std"]
-package = "sval_json"
-
-[dev-dependencies.serde1_json]
-version = "1"
-package = "serde_json"
+[dev-dependencies.value-bag-serde1]
+path = "meta/serde1"
+features = ["test", "json"]
 
 [dev-dependencies.wasm-bindgen]
 version = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ optional = true
 
 # Only needed on non-nightly compilers
 [dependencies.ctor]
-version = "0.1"
+version = "0.2"
 
 [dev-dependencies.value-bag-sval2]
 path = "meta/sval2"
@@ -81,10 +81,10 @@ features = ["test", "json"]
 path = "meta/serde1"
 features = ["test", "json"]
 
-[dev-dependencies.wasm-bindgen]
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies.wasm-bindgen]
 version = "0.2"
 
-[dev-dependencies.wasm-bindgen-test]
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies.wasm-bindgen-test]
 version = "0.3"
 
 [build-dependencies.rustc]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You'll probably also want to add a feature for either `sval` (if you're in a no-
 ```rust
 [dependencies.value-bag]
 version = "1.0.0-alpha.9"
-features = ["sval1"]
+features = ["sval2"]
 ```
 
 ```rust
@@ -50,8 +50,8 @@ The `value-bag` crate is no-std by default, and offers the following Cargo featu
 
 - `std`: Enable support for the standard library. This allows more types to be captured in a `ValueBag`.
 - `error`: Enable support for capturing `std::error::Error`s. Implies `std`.
-- `sval`: Enable support for using the [`sval`](https://github.com/sval-rs/sval) serialization framework for inspecting `ValueBag`s by implementing `sval::value::Value`. Implies `sval1`.
-    - `sval1`: Enable support for the stable `1.x.x` version of `sval`.
+- `sval`: Enable support for using the [`sval`](https://github.com/sval-rs/sval) serialization framework for inspecting `ValueBag`s by implementing `sval::value::Value`. Implies `sval2`.
+    - `sval2`: Enable support for the stable `1.x.x` version of `sval`.
 - `serde`: Enable support for using the [`serde`](https://github.com/serde-rs/serde) serialization framework for inspecting `ValueBag`s by implementing `serde::Serialize`. Implies `std` and `serde1`.
     - `serde1`: Enable support for the stable `1.x.x` version of `serde`.
 - `test`: Add test helpers for inspecting the shape of the value inside a `ValueBag`.
@@ -96,7 +96,7 @@ let work = Work {
     description: String::from("do the work"),
 }
 
-let bag = ValueBag::capture_sval1(&work);
+let bag = ValueBag::capture_sval2(&work);
 ```
 
 It could then be formatted using `Display`, even though `Work` never implemented that trait:
@@ -107,4 +107,4 @@ assert_eq!("Work { id: 123, description: \"do the work\" }", bag.to_string());
 
 Or serialized using `serde` and retain its nested structure.
 
-The tradeoff in all this is that `ValueBag` needs to depend on the serialization frameworks (`sval`, `serde`, and `std::fmt`) that it supports, instead of just providing an API of its own for others to plug into. Doing this lets `ValueBag` guarantee everything will always line up, and keep its own public API narrow. Each of these frameworks are stable though (except `sval` which is `1.0.0-alpha`).
+The tradeoff in all this is that `ValueBag` needs to depend on the serialization frameworks (`sval`, `serde`, and `std::fmt`) that it supports, instead of just providing an API of its own for others to plug into. Doing this lets `ValueBag` guarantee everything will always line up, and keep its own public API narrow. Each of these frameworks are stable though.

--- a/meta/serde1/Cargo.toml
+++ b/meta/serde1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "value-bag-serde1"
-version = "0.0.0"
+version = "1.0.0-alpha.9"
 edition = "2021"
 
 [features]

--- a/meta/serde1/Cargo.toml
+++ b/meta/serde1/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "value-bag-serde1"
+version = "0.0.0"
+edition = "2021"
+
+[features]
+std = [
+    "serde/std",
+    "erased-serde/std",
+]
+
+alloc = []
+
+json = [
+    "serde_json",
+]
+
+test = [
+    "serde_test",
+]
+
+[dependencies.serde]
+version = "1"
+features = ["alloc"]
+default-features = false
+
+[dependencies.erased-serde]
+version = "0.3"
+features = ["alloc"]
+default-features = false
+
+[dependencies.serde_fmt]
+version = "1"
+default-features = false
+
+[dependencies.serde_json]
+version = "1"
+optional = true
+
+[dependencies.serde_test]
+version = "1"
+optional = true

--- a/meta/serde1/src/lib.rs
+++ b/meta/serde1/src/lib.rs
@@ -1,0 +1,9 @@
+pub use serde as lib;
+pub use erased_serde as dynamic;
+pub use serde_fmt as fmt;
+
+#[cfg(feature = "json")]
+pub use serde_json as json;
+
+#[cfg(feature = "test")]
+pub use serde_test as test;

--- a/meta/serde1/src/lib.rs
+++ b/meta/serde1/src/lib.rs
@@ -1,5 +1,9 @@
+/*!
+Implementation detail for `value-bag`; it should not be depended on directly.
+*/
+
+pub use erased_serde as erased;
 pub use serde as lib;
-pub use erased_serde as dynamic;
 pub use serde_fmt as fmt;
 
 #[cfg(feature = "json")]

--- a/meta/serde1/src/lib.rs
+++ b/meta/serde1/src/lib.rs
@@ -2,6 +2,8 @@
 Implementation detail for `value-bag`; it should not be depended on directly.
 */
 
+#![no_std]
+
 pub use erased_serde as erased;
 pub use serde as lib;
 pub use serde_fmt as fmt;

--- a/meta/sval2/Cargo.toml
+++ b/meta/sval2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "value-bag-sval2"
-version = "0.0.0"
+version = "1.0.0-alpha.9"
 edition = "2021"
 
 [features]

--- a/meta/sval2/Cargo.toml
+++ b/meta/sval2/Cargo.toml
@@ -1,0 +1,58 @@
+[package]
+name = "value-bag-sval2"
+version = "0.0.0"
+edition = "2021"
+
+[features]
+std = [
+    "sval/std",
+    "sval_buffer/std",
+    "sval_serde?/std",
+]
+
+alloc = [
+    "sval/alloc",
+    "sval_buffer/alloc",
+    "sval_serde?/alloc",
+]
+
+serde1 = [
+    "sval_serde",
+]
+
+json = [
+    "sval_json",
+]
+
+test = [
+    "sval_test",
+]
+
+[dependencies.sval]
+version = "2"
+default-features = false
+
+[dependencies.sval_dynamic]
+version = "2"
+default-features = false
+
+[dependencies.sval_buffer]
+version = "2"
+default-features = false
+
+[dependencies.sval_fmt]
+version = "2"
+default-features = false
+
+[dependencies.sval_serde]
+version = "2"
+default-features = false
+optional = true
+
+[dependencies.sval_json]
+version = "2"
+optional = true
+
+[dependencies.sval_test]
+version = "2"
+optional = true

--- a/meta/sval2/Cargo.toml
+++ b/meta/sval2/Cargo.toml
@@ -8,12 +8,14 @@ std = [
     "sval/std",
     "sval_buffer/std",
     "sval_serde?/std",
+    "sval_json?/std",
 ]
 
 alloc = [
     "sval/alloc",
     "sval_buffer/alloc",
     "sval_serde?/alloc",
+    "sval_json?/alloc",
 ]
 
 serde1 = [
@@ -25,6 +27,7 @@ json = [
 ]
 
 test = [
+    "std",
     "sval_test",
 ]
 

--- a/meta/sval2/src/lib.rs
+++ b/meta/sval2/src/lib.rs
@@ -1,0 +1,13 @@
+pub use sval as lib;
+pub use sval_dynamic as dynamic;
+pub use sval_fmt as fmt;
+pub use sval_buffer as buffer;
+
+#[cfg(feature = "serde1")]
+pub use sval_serde as serde1;
+
+#[cfg(feature = "json")]
+pub use sval_json as json;
+
+#[cfg(feature = "test")]
+pub use sval_test as test;

--- a/meta/sval2/src/lib.rs
+++ b/meta/sval2/src/lib.rs
@@ -2,6 +2,8 @@
 Implementation detail for `value-bag`; it should not be depended on directly.
 */
 
+#![no_std]
+
 pub use sval as lib;
 pub use sval_buffer as buffer;
 pub use sval_dynamic as dynamic;

--- a/meta/sval2/src/lib.rs
+++ b/meta/sval2/src/lib.rs
@@ -1,7 +1,11 @@
+/*!
+Implementation detail for `value-bag`; it should not be depended on directly.
+*/
+
 pub use sval as lib;
+pub use sval_buffer as buffer;
 pub use sval_dynamic as dynamic;
 pub use sval_fmt as fmt;
-pub use sval_buffer as buffer;
 
 #[cfg(feature = "serde1")]
 pub use sval_serde as serde1;

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -82,7 +82,7 @@ mod tests {
 
     use crate::{
         std::{borrow::ToOwned, string::ToString},
-        test::{IntoValueBag, Token},
+        test::{IntoValueBag, TestToken},
     };
 
     #[test]
@@ -103,15 +103,18 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_into_structured() {
-        assert_eq!(42u64.into_value_bag().to_token(), Token::U64(42));
-        assert_eq!(42i64.into_value_bag().to_token(), Token::I64(42));
-        assert_eq!(42.01f64.into_value_bag().to_token(), Token::F64(42.01));
-        assert_eq!(true.into_value_bag().to_token(), Token::Bool(true));
-        assert_eq!('a'.into_value_bag().to_token(), Token::Char('a'));
+        assert_eq!(42u64.into_value_bag().to_test_token(), TestToken::U64(42));
+        assert_eq!(42i64.into_value_bag().to_test_token(), TestToken::I64(42));
         assert_eq!(
-            "a loong string".into_value_bag().to_token(),
-            Token::Str("a loong string".to_owned())
+            42.01f64.into_value_bag().to_test_token(),
+            TestToken::F64(42.01)
         );
-        assert_eq!(().into_value_bag().to_token(), Token::None);
+        assert_eq!(true.into_value_bag().to_test_token(), TestToken::Bool(true));
+        assert_eq!('a'.into_value_bag().to_test_token(), TestToken::Char('a'));
+        assert_eq!(
+            "a loong string".into_value_bag().to_test_token(),
+            TestToken::Str("a loong string".to_owned())
+        );
+        assert_eq!(().into_value_bag().to_test_token(), TestToken::None);
     }
 }

--- a/src/internal/cast/mod.rs
+++ b/src/internal/cast/mod.rs
@@ -106,7 +106,7 @@ impl<'v> ValueBag<'v> {
             Internal::Display(value) => value.as_any().downcast_ref(),
             #[cfg(feature = "error")]
             Internal::Error(value) => value.as_any().downcast_ref(),
-            #[cfg(feature = "")]
+            #[cfg(feature = "sval2")]
             Internal::Sval2(value) => value.as_any().downcast_ref(),
             #[cfg(feature = "serde1")]
             Internal::Serde1(value) => value.as_any().downcast_ref(),

--- a/src/internal/cast/mod.rs
+++ b/src/internal/cast/mod.rs
@@ -106,8 +106,8 @@ impl<'v> ValueBag<'v> {
             Internal::Display(value) => value.as_any().downcast_ref(),
             #[cfg(feature = "error")]
             Internal::Error(value) => value.as_any().downcast_ref(),
-            #[cfg(feature = "sval1")]
-            Internal::Sval1(value) => value.as_any().downcast_ref(),
+            #[cfg(feature = "")]
+            Internal::Sval2(value) => value.as_any().downcast_ref(),
             #[cfg(feature = "serde1")]
             Internal::Serde1(value) => value.as_any().downcast_ref(),
             _ => None,
@@ -205,10 +205,15 @@ impl<'v> Internal<'v> {
                 Ok(())
             }
 
-            #[cfg(feature = "sval1")]
+            #[cfg(feature = "sval2")]
             #[inline]
-            fn sval1(&mut self, v: &dyn super::sval::v1::Value) -> Result<(), Error> {
-                super::sval::v1::internal_visit(v, self)
+            fn sval2(&mut self, v: &dyn super::sval::v2::Value) -> Result<(), Error> {
+                super::sval::v2::internal_visit(v, self)
+            }
+
+            #[cfg(feature = "sval2")]
+            fn borrowed_sval2(&mut self, v: &'v dyn super::sval::v2::Value) -> Result<(), Error> {
+                super::sval::v2::borrowed_internal_visit(v, self)
             }
 
             #[cfg(feature = "serde1")]

--- a/src/internal/error.rs
+++ b/src/internal/error.rs
@@ -27,7 +27,7 @@ impl<'v> ValueBag<'v> {
 
     /// Try get an error from this value.
     #[inline]
-    pub fn to_borrowed_error(&self) -> Option<&(dyn Error + 'static)> {
+    pub fn to_borrowed_error(&self) -> Option<&'v (dyn Error + 'static)> {
         match self.inner {
             Internal::Error(value) => Some(value.as_super()),
             Internal::AnonError(value) => Some(value),

--- a/src/internal/error.rs
+++ b/src/internal/error.rs
@@ -122,7 +122,7 @@ mod tests {
         let err = io::Error::from(io::ErrorKind::Other);
 
         ValueBag::from_dyn_error(&err)
-            .visit(TestVisit)
+            .visit(TestVisit::default())
             .expect("failed to visit value");
     }
 }

--- a/src/internal/fmt.rs
+++ b/src/internal/fmt.rs
@@ -205,9 +205,9 @@ impl<'v> Debug for ValueBag<'v> {
                 Ok(())
             }
 
-            #[cfg(feature = "sval1")]
-            fn sval1(&mut self, v: &dyn crate::internal::sval::v1::Value) -> Result<(), Error> {
-                crate::internal::sval::v1::fmt(self.0, v)
+            #[cfg(feature = "sval2")]
+            fn sval2(&mut self, v: &dyn crate::internal::sval::v2::Value) -> Result<(), Error> {
+                crate::internal::sval::v2::fmt(self.0, v)
             }
 
             #[cfg(feature = "serde1")]
@@ -302,9 +302,9 @@ impl<'v> Display for ValueBag<'v> {
                 Ok(())
             }
 
-            #[cfg(feature = "sval1")]
-            fn sval1(&mut self, v: &dyn crate::internal::sval::v1::Value) -> Result<(), Error> {
-                crate::internal::sval::v1::fmt(self.0, v)
+            #[cfg(feature = "sval2")]
+            fn sval2(&mut self, v: &dyn crate::internal::sval::v2::Value) -> Result<(), Error> {
+                crate::internal::sval::v2::fmt(self.0, v)
             }
 
             #[cfg(feature = "serde1")]

--- a/src/internal/fmt.rs
+++ b/src/internal/fmt.rs
@@ -331,18 +331,24 @@ mod tests {
     use super::*;
     use crate::{
         std::string::ToString,
-        test::{IntoValueBag, Token},
+        test::{IntoValueBag, TestToken},
     };
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn fmt_capture() {
-        assert_eq!(ValueBag::capture_debug(&1u16).to_token(), Token::U64(1));
-        assert_eq!(ValueBag::capture_display(&1u16).to_token(), Token::U64(1));
+        assert_eq!(
+            ValueBag::capture_debug(&1u16).to_test_token(),
+            TestToken::U64(1)
+        );
+        assert_eq!(
+            ValueBag::capture_display(&1u16).to_test_token(),
+            TestToken::U64(1)
+        );
 
         assert_eq!(
-            ValueBag::capture_debug(&Some(1u16)).to_token(),
-            Token::U64(1)
+            ValueBag::capture_debug(&Some(1u16)).to_test_token(),
+            TestToken::U64(1)
         );
     }
 

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -15,7 +15,7 @@ pub(super) mod fill;
 pub(super) mod fmt;
 #[cfg(feature = "serde1")]
 pub(super) mod serde;
-#[cfg(feature = "sval1")]
+#[cfg(feature = "sval2")]
 pub(super) mod sval;
 
 // NOTE: It takes less space to have separate variants for the presence
@@ -63,12 +63,12 @@ pub(super) enum Internal<'v> {
     /// An error.
     Error(&'v dyn error::DowncastError),
 
-    #[cfg(feature = "sval1")]
+    #[cfg(feature = "sval2")]
     /// A structured value from `sval`.
-    AnonSval1(&'v dyn sval::v1::Value),
-    #[cfg(feature = "sval1")]
+    AnonSval2(&'v dyn sval::v2::Value),
+    #[cfg(feature = "sval2")]
     /// A structured value from `sval`.
-    Sval1(&'v dyn sval::v1::DowncastValue),
+    Sval2(&'v dyn sval::v2::DowncastValue),
 
     #[cfg(feature = "serde1")]
     /// A structured value from `serde`.
@@ -126,10 +126,10 @@ impl<'v> Internal<'v> {
             #[cfg(feature = "error")]
             Internal::Error(value) => visitor.borrowed_error(value.as_super()),
 
-            #[cfg(feature = "sval1")]
-            Internal::AnonSval1(value) => visitor.sval1(value),
-            #[cfg(feature = "sval1")]
-            Internal::Sval1(value) => visitor.sval1(value.as_super()),
+            #[cfg(feature = "sval2")]
+            Internal::AnonSval2(value) => visitor.sval2(value),
+            #[cfg(feature = "sval2")]
+            Internal::Sval2(value) => visitor.sval2(value.as_super()),
 
             #[cfg(feature = "serde1")]
             Internal::AnonSerde1(value) => visitor.serde1(value),
@@ -172,8 +172,13 @@ pub(super) trait InternalVisitor<'v> {
         self.error(v)
     }
 
-    #[cfg(feature = "sval1")]
-    fn sval1(&mut self, v: &dyn sval::v1::Value) -> Result<(), Error>;
+    #[cfg(feature = "sval2")]
+    fn sval2(&mut self, v: &dyn sval::v2::Value) -> Result<(), Error>;
+
+    #[cfg(feature = "sval2")]
+    fn borrowed_sval2(&mut self, v: &'v dyn sval::v2::Value) -> Result<(), Error> {
+        self.sval2(v)
+    }
 
     #[cfg(feature = "serde1")]
     fn serde1(&mut self, v: &dyn serde::v1::Serialize) -> Result<(), Error>;

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -127,9 +127,9 @@ impl<'v> Internal<'v> {
             Internal::Error(value) => visitor.borrowed_error(value.as_super()),
 
             #[cfg(feature = "sval2")]
-            Internal::AnonSval2(value) => visitor.sval2(value),
+            Internal::AnonSval2(value) => visitor.borrowed_sval2(value),
             #[cfg(feature = "sval2")]
-            Internal::Sval2(value) => visitor.sval2(value.as_super()),
+            Internal::Sval2(value) => visitor.borrowed_sval2(value.as_super()),
 
             #[cfg(feature = "serde1")]
             Internal::AnonSerde1(value) => visitor.serde1(value),

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -78,6 +78,50 @@ pub(super) enum Internal<'v> {
     Serde1(&'v dyn serde::v1::DowncastSerialize),
 }
 
+/// The internal serialization contract.
+pub(super) trait InternalVisitor<'v> {
+    fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error>;
+    fn display(&mut self, v: &dyn fmt::Display) -> Result<(), Error>;
+
+    fn u64(&mut self, v: u64) -> Result<(), Error>;
+    fn i64(&mut self, v: i64) -> Result<(), Error>;
+    fn u128(&mut self, v: &u128) -> Result<(), Error>;
+    fn borrowed_u128(&mut self, v: &'v u128) -> Result<(), Error> {
+        self.u128(v)
+    }
+    fn i128(&mut self, v: &i128) -> Result<(), Error>;
+    fn borrowed_i128(&mut self, v: &'v i128) -> Result<(), Error> {
+        self.i128(v)
+    }
+    fn f64(&mut self, v: f64) -> Result<(), Error>;
+    fn bool(&mut self, v: bool) -> Result<(), Error>;
+    fn char(&mut self, v: char) -> Result<(), Error>;
+
+    fn str(&mut self, v: &str) -> Result<(), Error>;
+    fn borrowed_str(&mut self, v: &'v str) -> Result<(), Error> {
+        self.str(v)
+    }
+
+    fn none(&mut self) -> Result<(), Error>;
+
+    #[cfg(feature = "error")]
+    fn error(&mut self, v: &(dyn error::Error + 'static)) -> Result<(), Error>;
+    #[cfg(feature = "error")]
+    fn borrowed_error(&mut self, v: &'v (dyn error::Error + 'static)) -> Result<(), Error> {
+        self.error(v)
+    }
+
+    #[cfg(feature = "sval2")]
+    fn sval2(&mut self, v: &dyn sval::v2::Value) -> Result<(), Error>;
+    #[cfg(feature = "sval2")]
+    fn borrowed_sval2(&mut self, v: &'v dyn sval::v2::Value) -> Result<(), Error> {
+        self.sval2(v)
+    }
+
+    #[cfg(feature = "serde1")]
+    fn serde1(&mut self, v: &dyn serde::v1::Serialize) -> Result<(), Error>;
+}
+
 impl<'v> ValueBag<'v> {
     /// Get a value from an internal primitive.
     pub(super) fn from_internal<T>(value: T) -> Self
@@ -137,51 +181,6 @@ impl<'v> Internal<'v> {
             Internal::Serde1(value) => visitor.serde1(value.as_super()),
         }
     }
-}
-
-/// The internal serialization contract.
-pub(super) trait InternalVisitor<'v> {
-    fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error>;
-    fn display(&mut self, v: &dyn fmt::Display) -> Result<(), Error>;
-
-    fn u64(&mut self, v: u64) -> Result<(), Error>;
-    fn i64(&mut self, v: i64) -> Result<(), Error>;
-    fn u128(&mut self, v: &u128) -> Result<(), Error>;
-    fn borrowed_u128(&mut self, v: &'v u128) -> Result<(), Error> {
-        self.u128(v)
-    }
-    fn i128(&mut self, v: &i128) -> Result<(), Error>;
-    fn borrowed_i128(&mut self, v: &'v i128) -> Result<(), Error> {
-        self.i128(v)
-    }
-    fn f64(&mut self, v: f64) -> Result<(), Error>;
-    fn bool(&mut self, v: bool) -> Result<(), Error>;
-    fn char(&mut self, v: char) -> Result<(), Error>;
-
-    fn str(&mut self, v: &str) -> Result<(), Error>;
-    fn borrowed_str(&mut self, v: &'v str) -> Result<(), Error> {
-        self.str(v)
-    }
-
-    fn none(&mut self) -> Result<(), Error>;
-
-    #[cfg(feature = "error")]
-    fn error(&mut self, v: &(dyn error::Error + 'static)) -> Result<(), Error>;
-    #[cfg(feature = "error")]
-    fn borrowed_error(&mut self, v: &'v (dyn error::Error + 'static)) -> Result<(), Error> {
-        self.error(v)
-    }
-
-    #[cfg(feature = "sval2")]
-    fn sval2(&mut self, v: &dyn sval::v2::Value) -> Result<(), Error>;
-
-    #[cfg(feature = "sval2")]
-    fn borrowed_sval2(&mut self, v: &'v dyn sval::v2::Value) -> Result<(), Error> {
-        self.sval2(v)
-    }
-
-    #[cfg(feature = "serde1")]
-    fn serde1(&mut self, v: &dyn serde::v1::Serialize) -> Result<(), Error>;
 }
 
 impl<'v> From<()> for Internal<'v> {

--- a/src/internal/serde/v1.rs
+++ b/src/internal/serde/v1.rs
@@ -35,6 +35,8 @@ impl<'v> ValueBag<'v> {
             inner: Internal::AnonSerde1(value),
         }
     }
+
+    // NOTE: no `from_dyn_serde1` until `erased-serde` stabilizes
 }
 
 pub(crate) trait DowncastSerialize {
@@ -442,7 +444,10 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn serde1_capture() {
-        assert_eq!(ValueBag::capture_serde1(&42u64).to_token(), Token::U64(42));
+        assert_eq!(
+            ValueBag::capture_serde1(&42u64).to_test_token(),
+            TestToken::U64(42)
+        );
     }
 
     #[test]

--- a/src/internal/serde/v1.rs
+++ b/src/internal/serde/v1.rs
@@ -10,7 +10,7 @@ use crate::{
     Error, ValueBag,
 };
 
-use serde1_lib::ser::{Error as SerdeError, Impossible};
+use value_bag_serde1::lib::ser::{Error as SerdeError, Impossible};
 
 impl<'v> ValueBag<'v> {
     /// Get a value from a structured type.
@@ -19,7 +19,7 @@ impl<'v> ValueBag<'v> {
     /// before resorting to using its `Value` implementation.
     pub fn capture_serde1<T>(value: &'v T) -> Self
     where
-        T: serde1_lib::Serialize + 'static,
+        T: value_bag_serde1::lib::Serialize + 'static,
     {
         Self::try_capture(value).unwrap_or(ValueBag {
             inner: Internal::Serde1(value),
@@ -29,7 +29,7 @@ impl<'v> ValueBag<'v> {
     /// Get a value from a structured type without capturing support.
     pub fn from_serde1<T>(value: &'v T) -> Self
     where
-        T: serde1_lib::Serialize,
+        T: value_bag_serde1::lib::Serialize,
     {
         ValueBag {
             inner: Internal::AnonSerde1(value),
@@ -42,7 +42,7 @@ pub(crate) trait DowncastSerialize {
     fn as_super(&self) -> &dyn Serialize;
 }
 
-impl<T: serde1_lib::Serialize + 'static> DowncastSerialize for T {
+impl<T: value_bag_serde1::lib::Serialize + 'static> DowncastSerialize for T {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -58,20 +58,20 @@ impl<'s, 'f> Slot<'s, 'f> {
     /// The given value doesn't need to satisfy any particular lifetime constraints.
     pub fn fill_serde1<T>(self, value: T) -> Result<(), Error>
     where
-        T: serde1_lib::Serialize,
+        T: value_bag_serde1::lib::Serialize,
     {
         self.fill(|visitor| visitor.serde1(&value))
     }
 }
 
-impl<'v> serde1_lib::Serialize for ValueBag<'v> {
+impl<'v> value_bag_serde1::lib::Serialize for ValueBag<'v> {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S: serde1_lib::Serializer,
+        S: value_bag_serde1::lib::Serializer,
     {
         struct Serde1Visitor<S>
         where
-            S: serde1_lib::Serializer,
+            S: value_bag_serde1::lib::Serializer,
         {
             inner: Option<S>,
             result: Option<Result<S::Ok, S::Error>>,
@@ -79,7 +79,7 @@ impl<'v> serde1_lib::Serialize for ValueBag<'v> {
 
         impl<S> Serde1Visitor<S>
         where
-            S: serde1_lib::Serializer,
+            S: value_bag_serde1::lib::Serializer,
         {
             fn result(&self) -> Result<(), Error> {
                 match self.result {
@@ -100,7 +100,7 @@ impl<'v> serde1_lib::Serialize for ValueBag<'v> {
 
         impl<'v, S> InternalVisitor<'v> for Serde1Visitor<S>
         where
-            S: serde1_lib::Serializer,
+            S: value_bag_serde1::lib::Serializer,
         {
             fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error> {
                 struct DebugToDisplay<T>(T);
@@ -174,14 +174,14 @@ impl<'v> serde1_lib::Serialize for ValueBag<'v> {
                 self.result()
             }
 
-            #[cfg(feature = "sval1")]
-            fn sval1(&mut self, v: &dyn crate::internal::sval::v1::Value) -> Result<(), Error> {
-                self.result = Some(crate::internal::sval::v1::serde(self.serializer()?, v));
+            #[cfg(feature = "sval2")]
+            fn sval2(&mut self, v: &dyn crate::internal::sval::v2::Value) -> Result<(), Error> {
+                self.result = Some(crate::internal::sval::v2::serde1(self.serializer()?, v));
                 self.result()
             }
 
             fn serde1(&mut self, v: &dyn Serialize) -> Result<(), Error> {
-                self.result = Some(erased_serde1_lib::serialize(v, self.serializer()?));
+                self.result = Some(value_bag_serde1::erased::serialize(v, self.serializer()?));
                 self.result()
             }
         }
@@ -198,20 +198,19 @@ impl<'v> serde1_lib::Serialize for ValueBag<'v> {
     }
 }
 
-pub use erased_serde1_lib::Serialize;
+pub use value_bag_serde1::erased::Serialize;
 
 pub(in crate::internal) fn fmt(f: &mut fmt::Formatter, v: &dyn Serialize) -> Result<(), Error> {
-    fmt::Debug::fmt(&serde1_fmt_lib::to_debug(v), f)?;
+    fmt::Debug::fmt(&value_bag_serde1::fmt::to_debug(v), f)?;
     Ok(())
 }
 
-#[cfg(feature = "sval1")]
-pub(in crate::internal) fn sval1(
-    s: &mut sval1_lib::value::Stream,
+#[cfg(feature = "sval2")]
+pub(in crate::internal) fn sval2<'sval, S: value_bag_sval2::lib::Stream<'sval> + ?Sized>(
+    s: &mut S,
     v: &dyn Serialize,
 ) -> Result<(), Error> {
-    sval1_lib::serde::v1::stream(s, v).map_err(Error::from_sval1)?;
-    Ok(())
+    value_bag_sval2::serde1::stream(s, v).map_err(Error::from_sval2)
 }
 
 pub(crate) fn internal_visit<'v>(
@@ -220,7 +219,7 @@ pub(crate) fn internal_visit<'v>(
 ) -> Result<(), Error> {
     struct VisitorSerializer<'a, 'v>(&'a mut dyn InternalVisitor<'v>);
 
-    impl<'a, 'v> serde1_lib::Serializer for VisitorSerializer<'a, 'v> {
+    impl<'a, 'v> value_bag_serde1::lib::Serializer for VisitorSerializer<'a, 'v> {
         type Ok = ();
         type Error = Unsupported;
 
@@ -290,7 +289,7 @@ pub(crate) fn internal_visit<'v>(
 
         fn serialize_some<T>(self, v: &T) -> Result<Self::Ok, Self::Error>
         where
-            T: serde1_lib::Serialize + ?Sized,
+            T: value_bag_serde1::lib::Serialize + ?Sized,
         {
             v.serialize(self)
         }
@@ -330,7 +329,7 @@ pub(crate) fn internal_visit<'v>(
             _: &T,
         ) -> Result<Self::Ok, Self::Error>
         where
-            T: serde1_lib::Serialize + ?Sized,
+            T: value_bag_serde1::lib::Serialize + ?Sized,
         {
             Err(Unsupported)
         }
@@ -343,7 +342,7 @@ pub(crate) fn internal_visit<'v>(
             _: &T,
         ) -> Result<Self::Ok, Self::Error>
         where
-            T: serde1_lib::Serialize + ?Sized,
+            T: value_bag_serde1::lib::Serialize + ?Sized,
         {
             Err(Unsupported)
         }
@@ -403,7 +402,7 @@ pub(crate) fn internal_visit<'v>(
         }
     }
 
-    erased_serde1_lib::serialize(v, VisitorSerializer(visitor)).map_err(|_| Error::serde())
+    value_bag_serde1::erased::serialize(v, VisitorSerializer(visitor)).map_err(|_| Error::serde())
 }
 
 impl Error {
@@ -421,7 +420,7 @@ impl fmt::Display for Unsupported {
     }
 }
 
-impl serde1_lib::ser::Error for Unsupported {
+impl value_bag_serde1::lib::ser::Error for Unsupported {
     fn custom<T>(_: T) -> Self
     where
         T: fmt::Display,
@@ -430,7 +429,7 @@ impl serde1_lib::ser::Error for Unsupported {
     }
 }
 
-impl serde1_lib::ser::StdError for Unsupported {}
+impl value_bag_serde1::lib::ser::StdError for Unsupported {}
 
 #[cfg(test)]
 mod tests {
@@ -497,10 +496,10 @@ mod tests {
         #[derive(Debug, PartialEq, Eq)]
         struct Timestamp(usize);
 
-        impl serde1_lib::Serialize for Timestamp {
+        impl value_bag_serde1::lib::Serialize for Timestamp {
             fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
             where
-                S: serde1_lib::Serializer,
+                S: value_bag_serde1::lib::Serializer,
             {
                 s.serialize_u64(self.0 as u64)
             }
@@ -519,7 +518,7 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn serde1_structured() {
-        use serde1_test::{assert_ser_tokens, Token};
+        use value_bag_serde1::test::{assert_ser_tokens, Token};
 
         assert_ser_tokens(&ValueBag::from(42u64), &[Token::U64(42)]);
     }
@@ -529,10 +528,10 @@ mod tests {
     fn serde1_debug() {
         struct TestSerde;
 
-        impl serde1_lib::Serialize for TestSerde {
+        impl value_bag_serde1::lib::Serialize for TestSerde {
             fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
             where
-                S: serde1_lib::Serializer,
+                S: value_bag_serde1::lib::Serializer,
             {
                 s.serialize_u64(42)
             }
@@ -569,25 +568,24 @@ mod tests {
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg(feature = "sval1")]
-    fn serde1_sval() {
-        use sval1_lib::test::Token;
+    #[cfg(feature = "sval2")]
+    fn serde1_sval2() {
+        use value_bag_sval2::test::Token;
 
         struct TestSerde;
 
-        impl serde1_lib::Serialize for TestSerde {
+        impl value_bag_serde1::lib::Serialize for TestSerde {
             fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
             where
-                S: serde1_lib::Serializer,
+                S: value_bag_serde1::lib::Serializer,
             {
                 s.serialize_u64(42)
             }
         }
 
-        assert_eq!(
-            vec![Token::Unsigned(42)],
-            sval1_lib::test::tokens(ValueBag::capture_serde1(&TestSerde))
-        );
+        let value = ValueBag::from_serde1(&TestSerde);
+
+        value_bag_sval2::test::assert_tokens(&value, &[Token::U64(42)]);
     }
 
     #[cfg(feature = "std")]

--- a/src/internal/serde/v1.rs
+++ b/src/internal/serde/v1.rs
@@ -547,22 +547,22 @@ mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn serde1_visit() {
         ValueBag::from_serde1(&42u64)
-            .visit(TestVisit)
+            .visit(TestVisit::default())
             .expect("failed to visit value");
         ValueBag::from_serde1(&-42i64)
-            .visit(TestVisit)
+            .visit(TestVisit::default())
             .expect("failed to visit value");
         ValueBag::from_serde1(&11f64)
-            .visit(TestVisit)
+            .visit(TestVisit::default())
             .expect("failed to visit value");
         ValueBag::from_serde1(&true)
-            .visit(TestVisit)
+            .visit(TestVisit::default())
             .expect("failed to visit value");
         ValueBag::from_serde1(&"some string")
-            .visit(TestVisit)
+            .visit(TestVisit::default())
             .expect("failed to visit value");
         ValueBag::from_serde1(&'n')
-            .visit(TestVisit)
+            .visit(TestVisit::default())
             .expect("failed to visit value");
     }
 

--- a/src/internal/sval/mod.rs
+++ b/src/internal/sval/mod.rs
@@ -1,1 +1,1 @@
-pub(crate) mod v1;
+pub(crate) mod v2;

--- a/src/internal/sval/v2.rs
+++ b/src/internal/sval/v2.rs
@@ -399,22 +399,25 @@ mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn sval2_visit() {
         ValueBag::from_sval2(&42u64)
-            .visit(TestVisit)
+            .visit(TestVisit::default())
             .expect("failed to visit value");
         ValueBag::from_sval2(&-42i64)
-            .visit(TestVisit)
+            .visit(TestVisit::default())
             .expect("failed to visit value");
         ValueBag::from_sval2(&11f64)
-            .visit(TestVisit)
+            .visit(TestVisit::default())
             .expect("failed to visit value");
         ValueBag::from_sval2(&true)
-            .visit(TestVisit)
+            .visit(TestVisit::default())
             .expect("failed to visit value");
-        ValueBag::from_sval2(&"some string")
-            .visit(TestVisit)
+        ValueBag::from_sval2(&"some borrowed string")
+            .visit(TestVisit::default())
             .expect("failed to visit value");
         ValueBag::from_sval2(&'n')
-            .visit(TestVisit)
+            .visit(TestVisit {
+                str: "n",
+                ..Default::default()
+            })
             .expect("failed to visit value");
     }
 

--- a/src/internal/sval/v2.rs
+++ b/src/internal/sval/v2.rs
@@ -33,6 +33,14 @@ impl<'v> ValueBag<'v> {
             inner: Internal::AnonSval2(value),
         }
     }
+
+    /// Get a value from a structured type without capturing support.
+    #[inline]
+    pub fn from_dyn_sval2(value: &'v dyn Value) -> Self {
+        ValueBag {
+            inner: Internal::AnonSval2(value),
+        }
+    }
 }
 
 pub(crate) trait DowncastValue {
@@ -294,7 +302,10 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn sval2_capture() {
-        assert_eq!(ValueBag::capture_sval2(&42u64).to_token(), Token::U64(42));
+        assert_eq!(
+            ValueBag::capture_sval2(&42u64).to_test_token(),
+            TestToken::U64(42)
+        );
     }
 
     #[test]

--- a/src/internal/sval/v2.rs
+++ b/src/internal/sval/v2.rs
@@ -325,6 +325,30 @@ mod tests {
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn sval2_capture_cast_borrowed_str() {
+        struct Number<'a>(&'a str);
+
+        impl<'a> value_bag_sval2::lib::Value for Number<'a> {
+            fn stream<'sval, S: value_bag_sval2::lib::Stream<'sval> + ?Sized>(
+                &'sval self,
+                stream: &mut S,
+            ) -> value_bag_sval2::lib::Result {
+                stream.tagged_begin(Some(&value_bag_sval2::lib::tags::NUMBER), None, None)?;
+                stream.value(self.0)?;
+                stream.tagged_end(Some(&value_bag_sval2::lib::tags::NUMBER), None, None)
+            }
+        }
+
+        assert_eq!(
+            "123.456e789",
+            ValueBag::capture_sval2(&Number("123.456e789"))
+                .to_borrowed_str()
+                .expect("invalid value")
+        );
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn sval2_from_cast() {
         assert_eq!(
             42u64,

--- a/src/internal/sval/v2.rs
+++ b/src/internal/sval/v2.rs
@@ -15,30 +15,22 @@ impl<'v> ValueBag<'v> {
     ///
     /// This method will attempt to capture the given value as a well-known primitive
     /// before resorting to using its `Value` implementation.
-    pub fn capture_sval1<T>(value: &'v T) -> Self
+    pub fn capture_sval2<T>(value: &'v T) -> Self
     where
-        T: Value + 'static,
+        T: value_bag_sval2::lib::Value + 'static,
     {
         Self::try_capture(value).unwrap_or(ValueBag {
-            inner: Internal::Sval1(value),
+            inner: Internal::Sval2(value),
         })
     }
 
     /// Get a value from a structured type without capturing support.
-    pub fn from_sval1<T>(value: &'v T) -> Self
+    pub fn from_sval2<T>(value: &'v T) -> Self
     where
-        T: Value,
+        T: value_bag_sval2::lib::Value,
     {
         ValueBag {
-            inner: Internal::AnonSval1(value),
-        }
-    }
-
-    /// Get a value from an erased structured type.
-    #[inline]
-    pub fn from_dyn_sval1(value: &'v dyn Value) -> Self {
-        ValueBag {
-            inner: Internal::AnonSval1(value),
+            inner: Internal::AnonSval2(value),
         }
     }
 }
@@ -48,7 +40,7 @@ pub(crate) trait DowncastValue {
     fn as_super(&self) -> &dyn Value;
 }
 
-impl<T: Value + 'static> DowncastValue for T {
+impl<T: value_bag_sval2::lib::Value + 'static> DowncastValue for T {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -62,75 +54,75 @@ impl<'s, 'f> Slot<'s, 'f> {
     /// Fill the slot with a structured value.
     ///
     /// The given value doesn't need to satisfy any particular lifetime constraints.
-    pub fn fill_sval1<T>(self, value: T) -> Result<(), Error>
+    pub fn fill_sval2<T>(self, value: T) -> Result<(), Error>
     where
-        T: Value,
+        T: value_bag_sval2::lib::Value,
     {
-        self.fill(|visitor| visitor.sval1(&value))
+        self.fill(|visitor| visitor.sval2(&value))
     }
 
     /// Fill the slot with a structured value.
-    pub fn fill_dyn_sval1(self, value: &dyn Value) -> Result<(), Error> {
-        self.fill(|visitor| visitor.sval1(value))
+    pub fn fill_dyn_sval2(self, value: &dyn Value) -> Result<(), Error> {
+        self.fill(|visitor| visitor.sval2(value))
     }
 }
 
-impl<'v> Value for ValueBag<'v> {
-    fn stream(&self, s: &mut sval1_lib::value::Stream) -> sval1_lib::value::Result {
-        struct Sval1Visitor<'a, 'b: 'a>(&'a mut sval1_lib::value::Stream<'b>);
+impl<'v> value_bag_sval2::lib::Value for ValueBag<'v> {
+    fn stream<'sval, S: value_bag_sval2::lib::Stream<'sval> + ?Sized>(&'sval self, s: &mut S) -> value_bag_sval2::lib::Result {
+        struct Sval2Visitor<'a, S: ?Sized>(&'a mut S);
 
-        impl<'a, 'b: 'a, 'v> InternalVisitor<'v> for Sval1Visitor<'a, 'b> {
+        impl<'a, 'v, S: value_bag_sval2::lib::Stream<'v> + ?Sized> InternalVisitor<'v> for Sval2Visitor<'a, S> {
             fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error> {
-                self.0.debug(v).map_err(Error::from_sval1)
+                todo!()
             }
 
             fn display(&mut self, v: &dyn fmt::Display) -> Result<(), Error> {
-                self.0.display(v).map_err(Error::from_sval1)
+                todo!()
             }
 
             fn u64(&mut self, v: u64) -> Result<(), Error> {
-                self.0.u64(v).map_err(Error::from_sval1)
+                todo!()
             }
 
             fn i64(&mut self, v: i64) -> Result<(), Error> {
-                self.0.i64(v).map_err(Error::from_sval1)
+                todo!()
             }
 
             fn u128(&mut self, v: &u128) -> Result<(), Error> {
-                self.0.u128(*v).map_err(Error::from_sval1)
+                todo!()
             }
 
             fn i128(&mut self, v: &i128) -> Result<(), Error> {
-                self.0.i128(*v).map_err(Error::from_sval1)
+                todo!()
             }
 
             fn f64(&mut self, v: f64) -> Result<(), Error> {
-                self.0.f64(v).map_err(Error::from_sval1)
+                todo!()
             }
 
             fn bool(&mut self, v: bool) -> Result<(), Error> {
-                self.0.bool(v).map_err(Error::from_sval1)
+                todo!()
             }
 
             fn char(&mut self, v: char) -> Result<(), Error> {
-                self.0.char(v).map_err(Error::from_sval1)
+                todo!()
             }
 
             fn str(&mut self, v: &str) -> Result<(), Error> {
-                self.0.str(v).map_err(Error::from_sval1)
+                todo!()
             }
 
             fn none(&mut self) -> Result<(), Error> {
-                self.0.none().map_err(Error::from_sval1)
+                todo!()
             }
 
             #[cfg(feature = "error")]
             fn error(&mut self, v: &(dyn std::error::Error + 'static)) -> Result<(), Error> {
-                self.0.error(v).map_err(Error::from_sval1)
+                todo!()
             }
 
-            fn sval1(&mut self, v: &dyn Value) -> Result<(), Error> {
-                self.0.any(v).map_err(Error::from_sval1)
+            fn sval2(&mut self, v: &dyn Value) -> Result<(), Error> {
+                todo!()
             }
 
             #[cfg(feature = "serde1")]
@@ -138,104 +130,107 @@ impl<'v> Value for ValueBag<'v> {
                 &mut self,
                 v: &dyn crate::internal::serde::v1::Serialize,
             ) -> Result<(), Error> {
-                crate::internal::serde::v1::sval1(self.0, v)
+                crate::internal::serde::v1::sval2(self.0, v)
             }
         }
 
-        self.internal_visit(&mut Sval1Visitor(s))
-            .map_err(Error::into_sval1)?;
+        self.internal_visit(&mut Sval2Visitor(s))
+            .map_err(Error::into_sval2)?;
 
         Ok(())
     }
 }
 
-pub use sval1_lib::value::Value;
+pub use value_bag_sval2::dynamic::Value;
 
 pub(in crate::internal) fn fmt(f: &mut fmt::Formatter, v: &dyn Value) -> Result<(), Error> {
-    sval1_lib::fmt::debug(f, v)?;
+    value_bag_sval2::fmt::stream_to_write(f, v)?;
     Ok(())
 }
 
 #[cfg(feature = "serde1")]
-pub(in crate::internal) fn serde<S>(s: S, v: &dyn Value) -> Result<S::Ok, S::Error>
+pub(in crate::internal) fn serde1<S>(s: S, v: &dyn Value) -> Result<S::Ok, S::Error>
 where
     S: serde1_lib::Serializer,
 {
-    sval1_lib::serde::v1::serialize(s, v)
+    value_bag_sval2::serde1::serialize(s, v)
 }
 
 pub(crate) fn internal_visit<'v>(
     v: &dyn Value,
     visitor: &mut dyn InternalVisitor<'v>,
 ) -> Result<(), Error> {
-    struct VisitorStream<'a, 'v>(&'a mut dyn InternalVisitor<'v>);
-
-    impl<'a, 'v> sval1_lib::stream::Stream for VisitorStream<'a, 'v> {
-        fn fmt(&mut self, v: sval1_lib::stream::Arguments) -> sval1_lib::stream::Result {
-            self.0.display(&v).map_err(Error::into_sval1)?;
-            Ok(())
-        }
-
-        #[cfg(feature = "error")]
-        fn error(&mut self, v: sval1_lib::stream::Source) -> sval1_lib::stream::Result {
-            self.0.error(v.get()).map_err(Error::into_sval1)?;
-            Ok(())
-        }
-
-        fn i64(&mut self, v: i64) -> sval1_lib::stream::Result {
-            self.0.i64(v).map_err(Error::into_sval1)?;
-            Ok(())
-        }
-
-        fn u64(&mut self, v: u64) -> sval1_lib::stream::Result {
-            self.0.u64(v).map_err(Error::into_sval1)?;
-            Ok(())
-        }
-
-        fn i128(&mut self, v: i128) -> sval1_lib::stream::Result {
-            self.0.i128(&v).map_err(Error::into_sval1)?;
-            Ok(())
-        }
-
-        fn u128(&mut self, v: u128) -> sval1_lib::stream::Result {
-            self.0.u128(&v).map_err(Error::into_sval1)?;
-            Ok(())
-        }
-
-        fn f64(&mut self, v: f64) -> sval1_lib::stream::Result {
-            self.0.f64(v).map_err(Error::into_sval1)?;
-            Ok(())
-        }
-
-        fn bool(&mut self, v: bool) -> sval1_lib::stream::Result {
-            self.0.bool(v).map_err(Error::into_sval1)?;
-            Ok(())
-        }
-
-        fn char(&mut self, v: char) -> sval1_lib::stream::Result {
-            self.0.char(v).map_err(Error::into_sval1)?;
-            Ok(())
-        }
-
-        fn str(&mut self, s: &str) -> sval1_lib::stream::Result {
-            self.0.str(s).map_err(Error::into_sval1)?;
-            Ok(())
-        }
-    }
-
     let mut visitor = VisitorStream(visitor);
-    sval1_lib::stream(&mut visitor, v).map_err(Error::from_sval1)?;
+    value_bag_sval2::lib::stream_computed(&mut visitor, v).map_err(Error::from_sval2)?;
 
     Ok(())
 }
 
+pub(crate) fn borrowed_internal_visit<'v>(
+    v: &'v dyn Value,
+    visitor: &mut dyn InternalVisitor<'v>,
+) -> Result<(), Error> {
+    let mut visitor = VisitorStream(visitor);
+    value_bag_sval2::lib::stream(&mut visitor, v).map_err(Error::from_sval2)?;
+
+    Ok(())
+}
+
+struct VisitorStream<'a, 'v>(&'a mut dyn InternalVisitor<'v>);
+
+impl<'a, 'v> value_bag_sval2::lib::Stream<'v> for VisitorStream<'a, 'v> {
+    fn null(&mut self) -> value_bag_sval2::lib::Result {
+        todo!()
+    }
+
+    fn bool(&mut self, v: bool) -> value_bag_sval2::lib::Result {
+        todo!()
+    }
+
+    fn i64(&mut self, v: i64) -> value_bag_sval2::lib::Result {
+        todo!()
+    }
+
+    fn f64(&mut self, v: f64) -> value_bag_sval2::lib::Result {
+        todo!()
+    }
+
+    fn text_begin(&mut self, _: Option<usize>) -> value_bag_sval2::lib::Result {
+        todo!()
+    }
+
+    fn text_fragment_computed(&mut self, f: &str) -> value_bag_sval2::lib::Result {
+        todo!()
+    }
+
+    fn text_end(&mut self) -> value_bag_sval2::lib::Result {
+        todo!()
+    }
+
+    fn seq_begin(&mut self, _: Option<usize>) -> value_bag_sval2::lib::Result {
+        todo!()
+    }
+
+    fn seq_value_begin(&mut self) -> value_bag_sval2::lib::Result {
+        todo!()
+    }
+
+    fn seq_value_end(&mut self) -> value_bag_sval2::lib::Result {
+        todo!()
+    }
+
+    fn seq_end(&mut self) -> value_bag_sval2::lib::Result {
+        todo!()
+    }
+}
+
 impl Error {
-    pub(in crate::internal) fn from_sval1(_: sval1_lib::Error) -> Self {
+    pub(in crate::internal) fn from_sval2(_: value_bag_sval2::lib::Error) -> Self {
         Error::msg("`sval` serialization failed")
     }
 
-    pub(in crate::internal) fn into_sval1(self) -> sval1_lib::Error {
-        sval1_lib::Error::msg("`sval` serialization failed")
+    pub(in crate::internal) fn into_sval2(self) -> value_bag_sval2::lib::Error {
+        value_bag_sval2::lib::Error::new()
     }
 }
 
@@ -249,23 +244,23 @@ mod tests {
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn sval1_capture() {
-        assert_eq!(ValueBag::capture_sval1(&42u64).to_token(), Token::U64(42));
+    fn sval2_capture() {
+        assert_eq!(ValueBag::capture_sval2(&42u64).to_token(), Token::U64(42));
     }
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn sval1_capture_cast() {
+    fn sval2_capture_cast() {
         assert_eq!(
             42u64,
-            ValueBag::capture_sval1(&42u64)
+            ValueBag::capture_sval2(&42u64)
                 .to_u64()
                 .expect("invalid value")
         );
 
         assert_eq!(
             "a string",
-            ValueBag::capture_sval1(&"a string")
+            ValueBag::capture_sval2(&"a string")
                 .to_borrowed_str()
                 .expect("invalid value")
         );
@@ -273,7 +268,7 @@ mod tests {
         #[cfg(feature = "std")]
         assert_eq!(
             "a string",
-            ValueBag::capture_sval1(&"a string")
+            ValueBag::capture_sval2(&"a string")
                 .to_str()
                 .expect("invalid value")
         );
@@ -281,10 +276,10 @@ mod tests {
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn sval1_from_cast() {
+    fn sval2_from_cast() {
         assert_eq!(
             42u64,
-            ValueBag::from_sval1(&42u64)
+            ValueBag::from_sval2(&42u64)
                 .to_u64()
                 .expect("invalid value")
         );
@@ -292,7 +287,7 @@ mod tests {
         #[cfg(feature = "std")]
         assert_eq!(
             "a string",
-            ValueBag::from_sval1(&"a string")
+            ValueBag::from_sval2(&"a string")
                 .to_str()
                 .expect("invalid value")
         );
@@ -300,12 +295,12 @@ mod tests {
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn sval1_downcast() {
+    fn sval2_downcast() {
         #[derive(Debug, PartialEq, Eq)]
         struct Timestamp(usize);
 
         impl Value for Timestamp {
-            fn stream(&self, stream: &mut sval1_lib::value::Stream) -> sval1_lib::value::Result {
+            fn stream(&self, stream: &mut value_bag_sval2::lib::value::Stream) -> value_bag_sval2::lib::value::Result {
                 stream.u64(self.0 as u64)
             }
         }
@@ -314,7 +309,7 @@ mod tests {
 
         assert_eq!(
             &ts,
-            ValueBag::capture_sval1(&ts)
+            ValueBag::capture_sval2(&ts)
                 .downcast_ref::<Timestamp>()
                 .expect("invalid value")
         );
@@ -322,49 +317,49 @@ mod tests {
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn sval1_structured() {
+    fn sval2_structured() {
         let value = ValueBag::from(42u64);
-        let expected = vec![sval1_lib::test::Token::Unsigned(42)];
+        let expected = vec![value_bag_sval2::lib::test::Token::Unsigned(42)];
 
-        assert_eq!(sval1_lib::test::tokens(value), expected);
+        assert_eq!(value_bag_sval2::lib::test::tokens(value), expected);
     }
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn sval1_debug() {
+    fn sval2_debug() {
         struct TestSval;
 
         impl Value for TestSval {
-            fn stream(&self, stream: &mut sval1_lib::value::Stream) -> sval1_lib::value::Result {
+            fn stream(&self, stream: &mut value_bag_sval2::lib::value::Stream) -> value_bag_sval2::lib::value::Result {
                 stream.u64(42)
             }
         }
 
         assert_eq!(
             format!("{:04?}", 42u64),
-            format!("{:04?}", ValueBag::capture_sval1(&TestSval)),
+            format!("{:04?}", ValueBag::capture_sval2(&TestSval)),
         );
     }
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn sval1_visit() {
-        ValueBag::from_dyn_sval1(&42u64)
+    fn sval2_visit() {
+        ValueBag::from_dyn_sval2(&42u64)
             .visit(TestVisit)
             .expect("failed to visit value");
-        ValueBag::from_dyn_sval1(&-42i64)
+        ValueBag::from_dyn_sval2(&-42i64)
             .visit(TestVisit)
             .expect("failed to visit value");
-        ValueBag::from_dyn_sval1(&11f64)
+        ValueBag::from_dyn_sval2(&11f64)
             .visit(TestVisit)
             .expect("failed to visit value");
-        ValueBag::from_dyn_sval1(&true)
+        ValueBag::from_dyn_sval2(&true)
             .visit(TestVisit)
             .expect("failed to visit value");
-        ValueBag::from_dyn_sval1(&"some string")
+        ValueBag::from_dyn_sval2(&"some string")
             .visit(TestVisit)
             .expect("failed to visit value");
-        ValueBag::from_dyn_sval1(&'n')
+        ValueBag::from_dyn_sval2(&'n')
             .visit(TestVisit)
             .expect("failed to visit value");
     }
@@ -372,24 +367,24 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg(feature = "serde1")]
-    fn sval1_serde1() {
+    fn sval2_serde1() {
         use serde1_test::{assert_ser_tokens, Token};
 
         struct TestSval;
 
         impl Value for TestSval {
-            fn stream(&self, stream: &mut sval1_lib::value::Stream) -> sval1_lib::value::Result {
+            fn stream(&self, stream: &mut value_bag_sval2::lib::value::Stream) -> value_bag_sval2::lib::value::Result {
                 stream.u64(42)
             }
         }
 
-        assert_ser_tokens(&ValueBag::capture_sval1(&TestSval), &[Token::U64(42)]);
+        assert_ser_tokens(&ValueBag::capture_sval2(&TestSval), &[Token::U64(42)]);
     }
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg(feature = "error")]
-    fn sval1_visit_error() {
+    fn sval2_visit_error() {
         use crate::{
             internal::sval::v1 as sval,
             std::{error, io},
@@ -399,7 +394,7 @@ mod tests {
         let value: &dyn sval::Value = &err;
 
         // Ensure that an error captured through `sval` can be visited as an error
-        ValueBag::from_dyn_sval1(value)
+        ValueBag::from_dyn_sval2(value)
             .visit(TestVisit)
             .expect("failed to visit value");
     }
@@ -412,10 +407,10 @@ mod tests {
 
         #[test]
         #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-        fn sval1_cast() {
+        fn sval2_cast() {
             assert_eq!(
                 "a string",
-                ValueBag::capture_sval1(&"a string".to_owned())
+                ValueBag::capture_sval2(&"a string".to_owned())
                     .to_str()
                     .expect("invalid value")
             );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,8 +223,8 @@ pub use self::error::Error;
 /// Then stream the contents of the `ValueBag` using `sval`.
 ///
 /// ```
-/// #[cfg(not(all(feature = "std", feature = "sval2")))] fn main() {}
-/// #[cfg(all(feature = "std", feature = "sval2"))]
+/// # #[cfg(not(all(feature = "std", feature = "sval2")))] fn main() {}
+/// # #[cfg(all(feature = "std", feature = "sval2"))]
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # use value_bag_sval2::json as sval_json;
 /// use value_bag::ValueBag;
@@ -253,8 +253,8 @@ pub use self::error::Error;
 /// Then stream the contents of the `ValueBag` using `serde`.
 ///
 /// ```
-/// #[cfg(not(all(feature = "std", feature = "serde1")))] fn main() {}
-/// #[cfg(all(feature = "std", feature = "serde1"))]
+/// # #[cfg(not(all(feature = "std", feature = "serde1")))] fn main() {}
+/// # #[cfg(all(feature = "std", feature = "serde1"))]
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # use value_bag_serde1::json as serde_json;
 /// use value_bag::ValueBag;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,80 +207,30 @@ pub use self::error::Error;
 ///
 /// ## Using `sval`
 ///
-/// When the `sval1` feature is enabled, any `ValueBag` can be serialized using `sval`.
+/// When the `sval2` feature is enabled, any `ValueBag` can be serialized using `sval`.
 /// This makes it possible to visit any typed structure captured in the `ValueBag`,
 /// including complex datatypes like maps and sequences.
 ///
 /// `sval` doesn't need to allocate so can be used in no-std environments.
 ///
-/// First, enable the `sval1` feature in your `Cargo.toml`:
+/// First, enable the `sval2` feature in your `Cargo.toml`:
 ///
 /// ```toml
 /// [dependencies.value-bag]
-/// features = ["sval1"]
+/// features = ["sval2"]
 /// ```
 ///
 /// Then stream the contents of the `ValueBag` using `sval`.
 ///
 /// ```
-/// #[cfg(not(all(feature = "std", feature = "sval1")))] fn main() {}
-/// #[cfg(all(feature = "std", feature = "sval1"))]
+/// #[cfg(not(all(feature = "std", feature = "sval2")))] fn main() {}
+/// #[cfg(all(feature = "std", feature = "sval2"))]
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// # extern crate sval1_json as sval_json;
+/// # use value_bag_sval2::json as sval_json;
 /// use value_bag::ValueBag;
 ///
 /// let value = ValueBag::from(42i64);
-/// let json = sval_json::to_string(value)?;
-/// # Ok(())
-/// # }
-/// ```
-///
-/// ```
-/// #[cfg(not(all(feature = "std", feature = "sval1")))] fn main() {}
-/// #[cfg(all(feature = "std", feature = "sval1"))]
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// # extern crate sval1_lib as sval;
-/// # fn escape(buf: &[u8]) -> &[u8] { buf }
-/// # fn itoa_fmt<T>(num: T) -> Vec<u8> { vec![] }
-/// # fn ryu_fmt<T>(num: T) -> Vec<u8> { vec![] }
-/// use value_bag::ValueBag;
-/// use sval::stream::{self, Stream};
-///
-/// // Implement some simple custom serialization
-/// struct MyStream(Vec<u8>);
-/// impl Stream for MyStream {
-///     fn u64(&mut self, v: u64) -> stream::Result {
-///         self.0.extend_from_slice(itoa_fmt(v).as_slice());
-///         Ok(())
-///     }
-///
-///     fn i64(&mut self, v: i64) -> stream::Result {
-///         self.0.extend_from_slice(itoa_fmt(v).as_slice());
-///         Ok(())
-///     }
-///
-///     fn f64(&mut self, v: f64) -> stream::Result {
-///         self.0.extend_from_slice(ryu_fmt(v).as_slice());
-///         Ok(())
-///     }
-///
-///     fn str(&mut self, v: &str) -> stream::Result {
-///         self.0.push(b'\"');
-///         self.0.extend_from_slice(escape(v.as_bytes()));
-///         self.0.push(b'\"');
-///         Ok(())
-///     }
-///
-///     fn bool(&mut self, v: bool) -> stream::Result {
-///         self.0.extend_from_slice(if v { b"true" } else { b"false" });
-///         Ok(())
-///     }
-/// }
-///
-/// let value = ValueBag::from(42i64);
-///
-/// let mut stream = MyStream(vec![]);
-/// sval::stream(&mut stream, &value)?;
+/// let json = sval_json::stream_to_string(value)?;
 /// # Ok(())
 /// # }
 /// ```
@@ -306,7 +256,7 @@ pub use self::error::Error;
 /// #[cfg(not(all(feature = "std", feature = "serde1")))] fn main() {}
 /// #[cfg(all(feature = "std", feature = "serde1"))]
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// # extern crate serde1_json as serde_json;
+/// # use value_bag_serde1::json as serde_json;
 /// use value_bag::ValueBag;
 ///
 /// let value = ValueBag::from(42i64);

--- a/src/test.rs
+++ b/src/test.rs
@@ -21,11 +21,11 @@ where
 }
 
 /**
-A tokenized representation of the captured value.
+A tokenized representation of the captured value for testing.
 */
 #[derive(Debug, PartialEq)]
 #[non_exhaustive]
-pub enum Token {
+pub enum TestToken {
     U64(u64),
     I64(i64),
     F64(f64),
@@ -40,28 +40,14 @@ pub enum Token {
     Error,
 
     #[cfg(feature = "sval2")]
-    Sval(Sval),
+    Sval {
+        version: u32,
+    },
 
     #[cfg(feature = "serde1")]
-    Serde(Serde),
-}
-
-/**
-A value that was captured using `sval`.
-*/
-#[derive(Debug, PartialEq)]
-#[non_exhaustive]
-pub struct Sval {
-    pub version: u32,
-}
-
-/**
-A value that was captured using `serde`.
-*/
-#[derive(Debug, PartialEq)]
-#[non_exhaustive]
-pub struct Serde {
-    pub version: u32,
+    Serde {
+        version: u32,
+    },
 }
 
 impl<'v> ValueBag<'v> {
@@ -70,80 +56,80 @@ impl<'v> ValueBag<'v> {
 
     This _isn't_ a general-purpose API for working with values outside of testing.
     */
-    pub fn to_token(&self) -> Token {
-        struct TestVisitor(Option<Token>);
+    pub fn to_test_token(&self) -> TestToken {
+        struct TestVisitor(Option<TestToken>);
 
         impl<'v> internal::InternalVisitor<'v> for TestVisitor {
             fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error> {
-                self.0 = Some(Token::Str(format!("{:?}", v)));
+                self.0 = Some(TestToken::Str(format!("{:?}", v)));
                 Ok(())
             }
 
             fn display(&mut self, v: &dyn fmt::Display) -> Result<(), Error> {
-                self.0 = Some(Token::Str(format!("{}", v)));
+                self.0 = Some(TestToken::Str(format!("{}", v)));
                 Ok(())
             }
 
             fn u64(&mut self, v: u64) -> Result<(), Error> {
-                self.0 = Some(Token::U64(v));
+                self.0 = Some(TestToken::U64(v));
                 Ok(())
             }
 
             fn i64(&mut self, v: i64) -> Result<(), Error> {
-                self.0 = Some(Token::I64(v));
+                self.0 = Some(TestToken::I64(v));
                 Ok(())
             }
 
             fn u128(&mut self, v: &u128) -> Result<(), Error> {
-                self.0 = Some(Token::U128(*v));
+                self.0 = Some(TestToken::U128(*v));
                 Ok(())
             }
 
             fn i128(&mut self, v: &i128) -> Result<(), Error> {
-                self.0 = Some(Token::I128(*v));
+                self.0 = Some(TestToken::I128(*v));
                 Ok(())
             }
 
             fn f64(&mut self, v: f64) -> Result<(), Error> {
-                self.0 = Some(Token::F64(v));
+                self.0 = Some(TestToken::F64(v));
                 Ok(())
             }
 
             fn bool(&mut self, v: bool) -> Result<(), Error> {
-                self.0 = Some(Token::Bool(v));
+                self.0 = Some(TestToken::Bool(v));
                 Ok(())
             }
 
             fn char(&mut self, v: char) -> Result<(), Error> {
-                self.0 = Some(Token::Char(v));
+                self.0 = Some(TestToken::Char(v));
                 Ok(())
             }
 
             fn str(&mut self, v: &str) -> Result<(), Error> {
-                self.0 = Some(Token::Str(v.into()));
+                self.0 = Some(TestToken::Str(v.into()));
                 Ok(())
             }
 
             fn none(&mut self) -> Result<(), Error> {
-                self.0 = Some(Token::None);
+                self.0 = Some(TestToken::None);
                 Ok(())
             }
 
             #[cfg(feature = "error")]
             fn error(&mut self, _: &dyn internal::error::Error) -> Result<(), Error> {
-                self.0 = Some(Token::Error);
+                self.0 = Some(TestToken::Error);
                 Ok(())
             }
 
             #[cfg(feature = "sval2")]
             fn sval2(&mut self, _: &dyn internal::sval::v2::Value) -> Result<(), Error> {
-                self.0 = Some(Token::Sval(Sval { version: 2 }));
+                self.0 = Some(TestToken::Sval { version: 2 });
                 Ok(())
             }
 
             #[cfg(feature = "serde1")]
             fn serde1(&mut self, _: &dyn internal::serde::v1::Serialize) -> Result<(), Error> {
-                self.0 = Some(Token::Serde(Serde { version: 1 }));
+                self.0 = Some(TestToken::Serde { version: 1 });
                 Ok(())
             }
         }

--- a/src/test.rs
+++ b/src/test.rs
@@ -39,7 +39,7 @@ pub enum Token {
     #[cfg(feature = "error")]
     Error,
 
-    #[cfg(feature = "sval1")]
+    #[cfg(feature = "sval2")]
     Sval(Sval),
 
     #[cfg(feature = "serde1")]
@@ -135,9 +135,9 @@ impl<'v> ValueBag<'v> {
                 Ok(())
             }
 
-            #[cfg(feature = "sval1")]
-            fn sval1(&mut self, _: &dyn internal::sval::v1::Value) -> Result<(), Error> {
-                self.0 = Some(Token::Sval(Sval { version: 1 }));
+            #[cfg(feature = "sval2")]
+            fn sval2(&mut self, _: &dyn internal::sval::v2::Value) -> Result<(), Error> {
+                self.0 = Some(Token::Sval(Sval { version: 2 }));
                 Ok(())
             }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -155,7 +155,33 @@ impl<'v> ValueBag<'v> {
     }
 }
 
-pub(crate) struct TestVisit;
+pub(crate) struct TestVisit {
+    pub i64: i64,
+    pub u64: u64,
+    pub i128: i128,
+    pub u128: u128,
+    pub f64: f64,
+    pub bool: bool,
+    pub str: &'static str,
+    pub borrowed_str: &'static str,
+    pub char: char,
+}
+
+impl Default for TestVisit {
+    fn default() -> Self {
+        TestVisit {
+            i64: -42,
+            u64: 42,
+            i128: -42,
+            u128: 42,
+            f64: 11.0,
+            bool: true,
+            str: "some string",
+            borrowed_str: "some borrowed string",
+            char: 'n',
+        }
+    }
+}
 
 impl<'v> Visit<'v> for TestVisit {
     fn visit_any(&mut self, v: ValueBag) -> Result<(), Error> {
@@ -163,47 +189,47 @@ impl<'v> Visit<'v> for TestVisit {
     }
 
     fn visit_i64(&mut self, v: i64) -> Result<(), Error> {
-        assert_eq!(-42i64, v);
+        assert_eq!(self.i64, v);
         Ok(())
     }
 
     fn visit_u64(&mut self, v: u64) -> Result<(), Error> {
-        assert_eq!(42u64, v);
+        assert_eq!(self.u64, v);
         Ok(())
     }
 
     fn visit_i128(&mut self, v: i128) -> Result<(), Error> {
-        assert_eq!(-42i128, v);
+        assert_eq!(self.i128, v);
         Ok(())
     }
 
     fn visit_u128(&mut self, v: u128) -> Result<(), Error> {
-        assert_eq!(42u128, v);
+        assert_eq!(self.u128, v);
         Ok(())
     }
 
     fn visit_f64(&mut self, v: f64) -> Result<(), Error> {
-        assert_eq!(11f64, v);
+        assert_eq!(self.f64, v);
         Ok(())
     }
 
     fn visit_bool(&mut self, v: bool) -> Result<(), Error> {
-        assert_eq!(true, v);
+        assert_eq!(self.bool, v);
         Ok(())
     }
 
     fn visit_str(&mut self, v: &str) -> Result<(), Error> {
-        assert_eq!("some string", v);
+        assert_eq!(self.str, v);
         Ok(())
     }
 
     fn visit_borrowed_str(&mut self, v: &'v str) -> Result<(), Error> {
-        assert_eq!("some string", v);
+        assert_eq!(self.borrowed_str, v);
         Ok(())
     }
 
     fn visit_char(&mut self, v: char) -> Result<(), Error> {
-        assert_eq!('n', v);
+        assert_eq!(self.char, v);
         Ok(())
     }
 

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -5,8 +5,8 @@
 //! More complex datatypes can then be handled using `std::fmt`, `sval`, or `serde`.
 //!
 //! ```
-//! #[cfg(not(feature = "std"))] fn main() {}
-//! #[cfg(feature = "std")]
+//! # #[cfg(not(feature = "std"))] fn main() {}
+//! # #[cfg(feature = "std")]
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! # fn escape(buf: &[u8]) -> &[u8] { buf }
 //! # fn itoa_fmt<T>(num: T) -> Vec<u8> { vec![] }

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -359,28 +359,28 @@ mod tests {
     #[test]
     fn visit_structured() {
         ValueBag::from(42u64)
-            .visit(TestVisit)
+            .visit(TestVisit::default())
             .expect("failed to visit value");
         ValueBag::from(-42i64)
-            .visit(TestVisit)
+            .visit(TestVisit::default())
             .expect("failed to visit value");
         ValueBag::from(&42u128)
-            .visit(TestVisit)
+            .visit(TestVisit::default())
             .expect("failed to visit value");
         ValueBag::from(&-42i128)
-            .visit(TestVisit)
+            .visit(TestVisit::default())
             .expect("failed to visit value");
         ValueBag::from(11f64)
-            .visit(TestVisit)
+            .visit(TestVisit::default())
             .expect("failed to visit value");
         ValueBag::from(true)
-            .visit(TestVisit)
+            .visit(TestVisit::default())
             .expect("failed to visit value");
-        ValueBag::from("some string")
-            .visit(TestVisit)
+        ValueBag::from("some borrowed string")
+            .visit(TestVisit::default())
             .expect("failed to visit value");
         ValueBag::from('n')
-            .visit(TestVisit)
+            .visit(TestVisit::default())
             .expect("failed to visit value");
     }
 }

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -328,9 +328,14 @@ impl<'v> ValueBag<'v> {
                 self.0.visit_borrowed_error(v)
             }
 
-            #[cfg(feature = "sval1")]
-            fn sval1(&mut self, v: &dyn internal::sval::v1::Value) -> Result<(), Error> {
-                internal::sval::v1::internal_visit(v, self)
+            #[cfg(feature = "sval2")]
+            fn sval2(&mut self, v: &dyn internal::sval::v2::Value) -> Result<(), Error> {
+                internal::sval::v2::internal_visit(v, self)
+            }
+
+            #[cfg(feature = "sval2")]
+            fn borrowed_sval2(&mut self, v: &'v dyn internal::sval::v2::Value) -> Result<(), Error> {
+                internal::sval::v2::borrowed_internal_visit(v, self)
             }
 
             #[cfg(feature = "serde1")]

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -334,7 +334,10 @@ impl<'v> ValueBag<'v> {
             }
 
             #[cfg(feature = "sval2")]
-            fn borrowed_sval2(&mut self, v: &'v dyn internal::sval::v2::Value) -> Result<(), Error> {
+            fn borrowed_sval2(
+                &mut self,
+                v: &'v dyn internal::sval::v2::Value,
+            ) -> Result<(), Error> {
                 internal::sval::v2::borrowed_internal_visit(v, self)
             }
 


### PR DESCRIPTION
This PR updates the `value-bag` library to the newly stabilised 2.x release of `sval`. This is the last blocker before being able to stabilise this library itself.