### PR TITLE
Prepare for 1.0.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "value-bag"
-version = "1.0.0-alpha.9"
+version = "1.0.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
@@ -60,12 +60,12 @@ error = [
 test = ["std"]
 
 [dependencies.value-bag-sval2]
-version = "1.0.0-alpha.9"
+version = "1.0.0"
 path = "meta/sval2"
 optional = true
 
 [dependencies.value-bag-serde1]
-version = "1.0.0-alpha.9"
+version = "1.0.0"
 path = "meta/serde1"
 optional = true
 

--- a/README.md
+++ b/README.md
@@ -10,20 +10,20 @@ Add the `value-bag` crate to your `Cargo.toml`:
 
 ```rust
 [dependencies.value-bag]
-version = "1.0.0-alpha.9"
+version = "1.0.0"
 ```
 
 You'll probably also want to add a feature for either `sval` (if you're in a no-std environment) or `serde` (if you need to integrate with other code that uses `serde`):
 
 ```rust
 [dependencies.value-bag]
-version = "1.0.0-alpha.9"
+version = "1.0.0"
 features = ["sval2"]
 ```
 
 ```rust
 [dependencies.value-bag]
-version = "1.0.0-alpha.9"
+version = "1.0.0"
 features = ["serde1"]
 ```
 

--- a/meta/serde1/Cargo.toml
+++ b/meta/serde1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "value-bag-serde1"
-version = "1.0.0-alpha.9"
+version = "1.0.0"
 edition = "2021"
 
 [features]

--- a/meta/sval2/Cargo.toml
+++ b/meta/sval2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "value-bag-sval2"
-version = "1.0.0-alpha.9"
+version = "1.0.0"
 edition = "2021"
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! consumer. They don't need to coordinate directly.
 
 #![cfg_attr(value_bag_capture_const_type_id, feature(const_type_id))]
-#![doc(html_root_url = "https://docs.rs/value-bag/1.0.0-alpha.9")]
+#![doc(html_root_url = "https://docs.rs/value-bag/1.0.0")]
 #![no_std]
 
 /*


### PR DESCRIPTION
This PR stabilises `value-bag` now that `sval` is also stable. I've included release notes since the last stable release.

## What's Changed
* Prepare for 1.0.0-alpha.1 release by @KodrAus in https://github.com/sval-rs/value-bag/pull/4
* Make fill and test modules public by @KodrAus in https://github.com/sval-rs/value-bag/pull/5
* Version the serde and sval support by @KodrAus in https://github.com/sval-rs/value-bag/pull/7
* Prepare for 1.0.0-alpha.2 release by @KodrAus in https://github.com/sval-rs/value-bag/pull/8
* Fix the test feature when not compiled with std by @KodrAus in https://github.com/sval-rs/value-bag/pull/9
* Prepare for 1.0.0-alpha.3 release by @KodrAus in https://github.com/sval-rs/value-bag/pull/10
* Always use &dyn Error + 'static by @KodrAus in https://github.com/sval-rs/value-bag/pull/11
* Prepare for 1.0.0-alpha.4 release by @KodrAus in https://github.com/sval-rs/value-bag/pull/12
* Detect invalid feature combinations in CI by @KodrAus in https://github.com/sval-rs/value-bag/pull/13
* Prepare for 1.0.0-alpha.5 release by @KodrAus in https://github.com/sval-rs/value-bag/pull/14
* Add a zero-dependency Visit API to ValueBag by @KodrAus in https://github.com/sval-rs/value-bag/pull/16
* Rework casting to remove `as` conversions by @KodrAus in https://github.com/sval-rs/value-bag/pull/17
* Align value-bag CI with sval by @KodrAus in https://github.com/sval-rs/value-bag/pull/20
* Prepare for 1.0.0-alpha.6 release by @KodrAus in https://github.com/sval-rs/value-bag/pull/21
* Fix up broken doc rendering by @KodrAus in https://github.com/sval-rs/value-bag/pull/24
* Fix up build detection around ctor by @KodrAus in https://github.com/sval-rs/value-bag/pull/25
* Prepare for 1.0.0-alpha.7 release by @KodrAus in https://github.com/sval-rs/value-bag/pull/26
* Add a by-ref method as an alternative to deriving Copy by @KodrAus in https://github.com/sval-rs/value-bag/pull/27
* str capturing by @KodrAus in https://github.com/sval-rs/value-bag/pull/28
* Allow capturing Strings as strs by @KodrAus in https://github.com/sval-rs/value-bag/pull/29
* Prepare for 1.0.0-alpha.8 release by @KodrAus in https://github.com/sval-rs/value-bag/pull/31
* Add some basic benches by @KodrAus in https://github.com/sval-rs/value-bag/pull/32
* Pass Slot by value instead of by reference by @KodrAus in https://github.com/sval-rs/value-bag/pull/33
* Add a few more capturing benches by @KodrAus in https://github.com/sval-rs/value-bag/pull/35
* Shrink ValueBag size by @KodrAus in https://github.com/sval-rs/value-bag/pull/36
* Prepare for 1.0.0-alpha.9 release by @KodrAus in https://github.com/sval-rs/value-bag/pull/37
* Reduce ValueBag size to 24 bytes by @KodrAus in https://github.com/sval-rs/value-bag/pull/38
* Update to sval 2.x by @KodrAus in https://github.com/sval-rs/value-bag/pull/41