### PR TITLE
Prepare for 1.0.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "value-bag"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
@@ -60,12 +60,12 @@ error = [
 test = ["std"]
 
 [dependencies.value-bag-sval2]
-version = "1.0.0"
+version = "1.0.1"
 path = "meta/sval2"
 optional = true
 
 [dependencies.value-bag-serde1]
-version = "1.0.0"
+version = "1.0.1"
 path = "meta/serde1"
 optional = true
 

--- a/README.md
+++ b/README.md
@@ -10,20 +10,20 @@ Add the `value-bag` crate to your `Cargo.toml`:
 
 ```rust
 [dependencies.value-bag]
-version = "1.0.0"
+version = "1.0.1"
 ```
 
 You'll probably also want to add a feature for either `sval` (if you're in a no-std environment) or `serde` (if you need to integrate with other code that uses `serde`):
 
 ```rust
 [dependencies.value-bag]
-version = "1.0.0"
+version = "1.0.1"
 features = ["sval2"]
 ```
 
 ```rust
 [dependencies.value-bag]
-version = "1.0.0"
+version = "1.0.1"
 features = ["serde1"]
 ```
 

--- a/meta/serde1/Cargo.toml
+++ b/meta/serde1/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "value-bag-serde1"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
+authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
+license = "Apache-2.0 OR MIT"
+description = "Implementation detail for value-bag"
 
 [features]
 std = [

--- a/meta/sval2/Cargo.toml
+++ b/meta/sval2/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "value-bag-sval2"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
+authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
+license = "Apache-2.0 OR MIT"
+description = "Implementation detail for value-bag"
 
 [features]
 std = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! consumer. They don't need to coordinate directly.
 
 #![cfg_attr(value_bag_capture_const_type_id, feature(const_type_id))]
-#![doc(html_root_url = "https://docs.rs/value-bag/1.0.0")]
+#![doc(html_root_url = "https://docs.rs/value-bag/1.0.1")]
 #![no_std]
 
 /*


### PR DESCRIPTION
Adds some missing Cargo metadata for crate publishing.