### PR TITLE
Use concrete 'v lifetime instead of short-lived in to_str and to_borrowed_str

### DIFF
--- a/src/internal/cast/mod.rs
+++ b/src/internal/cast/mod.rs
@@ -363,7 +363,7 @@ mod std_support {
         /// serialization implementations for complex ones. If the serialization
         /// implementation produces a short lived string it will be allocated.
         #[inline]
-        pub fn to_str(&self) -> Option<Cow<str>> {
+        pub fn to_str(&self) -> Option<Cow<'v, str>> {
             self.inner.cast().into_str()
         }
     }

--- a/src/internal/cast/mod.rs
+++ b/src/internal/cast/mod.rs
@@ -90,7 +90,7 @@ impl<'v> ValueBag<'v> {
     ///
     /// This method is cheap for primitive types. It won't allocate an owned
     /// `String` if the value is a complex type.
-    pub fn to_borrowed_str(&self) -> Option<&str> {
+    pub fn to_borrowed_str(&self) -> Option<&'v str> {
         self.inner.cast().into_borrowed_str()
     }
 


### PR DESCRIPTION
These methods were returning a shorter-than-necessary lifetime. If we're able to get a borrowed `str` then we're guaranteed to have a `&'v str`, so should use the longer lifetime in the signature.