### PR TITLE
Prepare for 1.0.2 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "value-bag"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
@@ -60,12 +60,12 @@ error = [
 test = ["std"]
 
 [dependencies.value-bag-sval2]
-version = "1.0.1"
+version = "1.0.2"
 path = "meta/sval2"
 optional = true
 
 [dependencies.value-bag-serde1]
-version = "1.0.1"
+version = "1.0.2"
 path = "meta/serde1"
 optional = true
 

--- a/meta/serde1/Cargo.toml
+++ b/meta/serde1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "value-bag-serde1"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0 OR MIT"

--- a/meta/sval2/Cargo.toml
+++ b/meta/sval2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "value-bag-sval2"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0 OR MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! consumer. They don't need to coordinate directly.
 
 #![cfg_attr(value_bag_capture_const_type_id, feature(const_type_id))]
-#![doc(html_root_url = "https://docs.rs/value-bag/1.0.1")]
+#![doc(html_root_url = "https://docs.rs/value-bag/1.0.2")]
 #![no_std]
 
 /*


### PR DESCRIPTION
## What's Changed
* Fix version ref in readme by @KodrAus in https://github.com/sval-rs/value-bag/pull/44
* Use concrete 'v lifetime instead of short-lived in to_str and to_borrowed_str by @KodrAus in https://github.com/sval-rs/value-bag/pull/45