### PR TITLE
Implement sval_ref::ValueRef for ValueBag

### DIFF
--- a/meta/sval2/Cargo.toml
+++ b/meta/sval2/Cargo.toml
@@ -9,6 +9,7 @@ description = "Implementation detail for value-bag"
 [features]
 std = [
     "sval/std",
+    "sval_ref/std",
     "sval_buffer/std",
     "sval_serde?/std",
     "sval_json?/std",
@@ -16,6 +17,7 @@ std = [
 
 alloc = [
     "sval/alloc",
+    "sval_ref/alloc",
     "sval_buffer/alloc",
     "sval_serde?/alloc",
     "sval_json?/alloc",
@@ -35,30 +37,34 @@ test = [
 ]
 
 [dependencies.sval]
-version = "2"
+version = "2.1"
+default-features = false
+
+[dependencies.sval_ref]
+version = "2.1"
 default-features = false
 
 [dependencies.sval_dynamic]
-version = "2"
+version = "2.1"
 default-features = false
 
 [dependencies.sval_buffer]
-version = "2"
+version = "2.1"
 default-features = false
 
 [dependencies.sval_fmt]
-version = "2"
+version = "2.1"
 default-features = false
 
 [dependencies.sval_serde]
-version = "2"
+version = "2.1"
 default-features = false
 optional = true
 
 [dependencies.sval_json]
-version = "2"
+version = "2.1"
 optional = true
 
 [dependencies.sval_test]
-version = "2"
+version = "2.1"
 optional = true

--- a/meta/sval2/src/lib.rs
+++ b/meta/sval2/src/lib.rs
@@ -8,6 +8,7 @@ pub use sval as lib;
 pub use sval_buffer as buffer;
 pub use sval_dynamic as dynamic;
 pub use sval_fmt as fmt;
+pub use sval_ref as lib_ref;
 
 #[cfg(feature = "serde1")]
 pub use sval_serde as serde1;

--- a/src/internal/sval/v2.rs
+++ b/src/internal/sval/v2.rs
@@ -75,6 +75,17 @@ impl<'v> value_bag_sval2::lib::Value for ValueBag<'v> {
         &'sval self,
         s: &mut S,
     ) -> value_bag_sval2::lib::Result {
+        use value_bag_sval2::lib_ref::ValueRef as _;
+
+        self.stream_ref(s)
+    }
+}
+
+impl<'sval> value_bag_sval2::lib_ref::ValueRef<'sval> for ValueBag<'sval> {
+    fn stream_ref<S: value_bag_sval2::lib::Stream<'sval> + ?Sized>(
+        &self,
+        s: &mut S,
+    ) -> value_bag_sval2::lib::Result {
         struct Sval2Visitor<'a, S: ?Sized>(&'a mut S);
 
         impl<'a, 'v, S: value_bag_sval2::lib::Stream<'v> + ?Sized> InternalVisitor<'v>


### PR DESCRIPTION
This makes it possible to stream the contents of a `ValueBag<'v>` for the `'v` lifetime through `sval` without needing to borrow the `ValueBag` itself for `'v`.