### PR TITLE
Remove Copy bound from internal enum

### DIFF
--- a/benches/by_ref.rs
+++ b/benches/by_ref.rs
@@ -1,0 +1,11 @@
+#![feature(test)]
+
+extern crate test;
+
+use value_bag::ValueBag;
+
+#[bench]
+fn u8_by_ref(b: &mut test::Bencher) {
+    let v = ValueBag::from(1u8);
+    b.iter(|| v.by_ref())
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,7 +46,7 @@ mod std_support {
     use super::*;
     use crate::std::{boxed::Box, error, io};
 
-    pub(super) type BoxedError = Box<dyn error::Error + Send + Sync>;
+    pub(crate) type BoxedError = Box<dyn error::Error + Send + Sync>;
 
     impl Error {
         /// Create an error from a standard error type.

--- a/src/fill.rs
+++ b/src/fill.rs
@@ -74,11 +74,11 @@ impl<'s, 'f> fmt::Debug for Slot<'s, 'f> {
 }
 
 impl<'s, 'f> Slot<'s, 'f> {
-    pub(super) fn new(visitor: &'s mut dyn InternalVisitor<'f>) -> Self {
+    pub(crate) fn new(visitor: &'s mut dyn InternalVisitor<'f>) -> Self {
         Slot { visitor }
     }
 
-    pub(super) fn fill<F>(self, f: F) -> Result<(), Error>
+    pub(crate) fn fill<F>(self, f: F) -> Result<(), Error>
     where
         F: FnOnce(&mut dyn InternalVisitor<'f>) -> Result<(), Error>,
     {

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -88,33 +88,48 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_into_display() {
-        assert_eq!(42u64.into_value_bag().to_string(), "42");
-        assert_eq!(42i64.into_value_bag().to_string(), "42");
-        assert_eq!(42.01f64.into_value_bag().to_string(), "42.01");
-        assert_eq!(true.into_value_bag().to_string(), "true");
-        assert_eq!('a'.into_value_bag().to_string(), "a");
+        assert_eq!(42u64.into_value_bag().by_ref().to_string(), "42");
+        assert_eq!(42i64.into_value_bag().by_ref().to_string(), "42");
+        assert_eq!(42.01f64.into_value_bag().by_ref().to_string(), "42.01");
+        assert_eq!(true.into_value_bag().by_ref().to_string(), "true");
+        assert_eq!('a'.into_value_bag().by_ref().to_string(), "a");
         assert_eq!(
-            "a loong string".into_value_bag().to_string(),
+            "a loong string".into_value_bag().by_ref().to_string(),
             "a loong string"
         );
-        assert_eq!(().into_value_bag().to_string(), "None");
+        assert_eq!(().into_value_bag().by_ref().to_string(), "None");
     }
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_into_structured() {
-        assert_eq!(42u64.into_value_bag().to_test_token(), TestToken::U64(42));
-        assert_eq!(42i64.into_value_bag().to_test_token(), TestToken::I64(42));
         assert_eq!(
-            42.01f64.into_value_bag().to_test_token(),
+            42u64.into_value_bag().by_ref().to_test_token(),
+            TestToken::U64(42)
+        );
+        assert_eq!(
+            42i64.into_value_bag().by_ref().to_test_token(),
+            TestToken::I64(42)
+        );
+        assert_eq!(
+            42.01f64.into_value_bag().by_ref().to_test_token(),
             TestToken::F64(42.01)
         );
-        assert_eq!(true.into_value_bag().to_test_token(), TestToken::Bool(true));
-        assert_eq!('a'.into_value_bag().to_test_token(), TestToken::Char('a'));
         assert_eq!(
-            "a loong string".into_value_bag().to_test_token(),
+            true.into_value_bag().by_ref().to_test_token(),
+            TestToken::Bool(true)
+        );
+        assert_eq!(
+            'a'.into_value_bag().by_ref().to_test_token(),
+            TestToken::Char('a')
+        );
+        assert_eq!(
+            "a loong string".into_value_bag().by_ref().to_test_token(),
             TestToken::Str("a loong string".to_owned())
         );
-        assert_eq!(().into_value_bag().to_test_token(), TestToken::None);
+        assert_eq!(
+            ().into_value_bag().by_ref().to_test_token(),
+            TestToken::None
+        );
     }
 }

--- a/src/internal/cast/mod.rs
+++ b/src/internal/cast/mod.rs
@@ -118,7 +118,7 @@ impl<'v> ValueBag<'v> {
 impl<'v> Internal<'v> {
     /// Cast the inner value to another type.
     #[inline]
-    fn cast(self) -> Cast<'v> {
+    fn cast(&self) -> Cast<'v> {
         struct CastVisitor<'v>(Cast<'v>);
 
         impl<'v> InternalVisitor<'v> for CastVisitor<'v> {
@@ -450,71 +450,134 @@ mod tests {
             "a string",
             "a string"
                 .into_value_bag()
+                .by_ref()
                 .to_borrowed_str()
                 .expect("invalid value")
         );
 
-        assert_eq!(1u64, 1u8.into_value_bag().to_u64().expect("invalid value"));
-        assert_eq!(1u64, 1u16.into_value_bag().to_u64().expect("invalid value"));
-        assert_eq!(1u64, 1u32.into_value_bag().to_u64().expect("invalid value"));
-        assert_eq!(1u64, 1u64.into_value_bag().to_u64().expect("invalid value"));
         assert_eq!(
             1u64,
-            1usize.into_value_bag().to_u64().expect("invalid value")
+            1u8.into_value_bag()
+                .by_ref()
+                .to_u64()
+                .expect("invalid value")
+        );
+        assert_eq!(
+            1u64,
+            1u16.into_value_bag()
+                .by_ref()
+                .to_u64()
+                .expect("invalid value")
+        );
+        assert_eq!(
+            1u64,
+            1u32.into_value_bag()
+                .by_ref()
+                .to_u64()
+                .expect("invalid value")
+        );
+        assert_eq!(
+            1u64,
+            1u64.into_value_bag()
+                .by_ref()
+                .to_u64()
+                .expect("invalid value")
+        );
+        assert_eq!(
+            1u64,
+            1usize
+                .into_value_bag()
+                .by_ref()
+                .to_u64()
+                .expect("invalid value")
         );
         assert_eq!(
             1u128,
-            1u128.into_value_bag().to_u128().expect("invalid value")
+            1u128
+                .into_value_bag()
+                .by_ref()
+                .to_u128()
+                .expect("invalid value")
         );
 
         assert_eq!(
             -1i64,
-            -1i8.into_value_bag().to_i64().expect("invalid value")
+            -1i8.into_value_bag()
+                .by_ref()
+                .to_i64()
+                .expect("invalid value")
         );
         assert_eq!(
             -1i64,
-            -1i8.into_value_bag().to_i64().expect("invalid value")
+            -1i8.into_value_bag()
+                .by_ref()
+                .to_i64()
+                .expect("invalid value")
         );
         assert_eq!(
             -1i64,
-            -1i8.into_value_bag().to_i64().expect("invalid value")
+            -1i8.into_value_bag()
+                .by_ref()
+                .to_i64()
+                .expect("invalid value")
         );
         assert_eq!(
             -1i64,
-            -1i64.into_value_bag().to_i64().expect("invalid value")
+            -1i64
+                .into_value_bag()
+                .by_ref()
+                .to_i64()
+                .expect("invalid value")
         );
         assert_eq!(
             -1i64,
-            -1isize.into_value_bag().to_i64().expect("invalid value")
+            -1isize
+                .into_value_bag()
+                .by_ref()
+                .to_i64()
+                .expect("invalid value")
         );
         assert_eq!(
             -1i128,
-            -1i128.into_value_bag().to_i128().expect("invalid value")
+            -1i128
+                .into_value_bag()
+                .by_ref()
+                .to_i128()
+                .expect("invalid value")
         );
 
-        assert!(1f64.into_value_bag().to_f64().is_some());
-        assert!(1u64.into_value_bag().to_f64().is_some());
-        assert!((-1i64).into_value_bag().to_f64().is_some());
-        assert!(1u128.into_value_bag().to_f64().is_some());
-        assert!((-1i128).into_value_bag().to_f64().is_some());
+        assert!(1f64.into_value_bag().by_ref().to_f64().is_some());
+        assert!(1u64.into_value_bag().by_ref().to_f64().is_some());
+        assert!((-1i64).into_value_bag().by_ref().to_f64().is_some());
+        assert!(1u128.into_value_bag().by_ref().to_f64().is_some());
+        assert!((-1i128).into_value_bag().by_ref().to_f64().is_some());
 
-        assert!(u64::MAX.into_value_bag().to_u128().is_some());
-        assert!(i64::MIN.into_value_bag().to_i128().is_some());
-        assert!(i64::MAX.into_value_bag().to_u64().is_some());
+        assert!(u64::MAX.into_value_bag().by_ref().to_u128().is_some());
+        assert!(i64::MIN.into_value_bag().by_ref().to_i128().is_some());
+        assert!(i64::MAX.into_value_bag().by_ref().to_u64().is_some());
 
-        assert!((-1i64).into_value_bag().to_u64().is_none());
-        assert!(u64::MAX.into_value_bag().to_i64().is_none());
-        assert!(u64::MAX.into_value_bag().to_f64().is_none());
+        assert!((-1i64).into_value_bag().by_ref().to_u64().is_none());
+        assert!(u64::MAX.into_value_bag().by_ref().to_i64().is_none());
+        assert!(u64::MAX.into_value_bag().by_ref().to_f64().is_none());
 
-        assert!(i128::MAX.into_value_bag().to_i64().is_none());
-        assert!(u128::MAX.into_value_bag().to_u64().is_none());
+        assert!(i128::MAX.into_value_bag().by_ref().to_i64().is_none());
+        assert!(u128::MAX.into_value_bag().by_ref().to_u64().is_none());
 
-        assert!(1f64.into_value_bag().to_u64().is_none());
+        assert!(1f64.into_value_bag().by_ref().to_u64().is_none());
 
-        assert_eq!('a', 'a'.into_value_bag().to_char().expect("invalid value"));
+        assert_eq!(
+            'a',
+            'a'.into_value_bag()
+                .by_ref()
+                .to_char()
+                .expect("invalid value")
+        );
         assert_eq!(
             true,
-            true.into_value_bag().to_bool().expect("invalid value")
+            true.into_value_bag()
+                .by_ref()
+                .to_bool()
+                .expect("invalid value")
         );
     }
 }

--- a/src/internal/cast/mod.rs
+++ b/src/internal/cast/mod.rs
@@ -370,7 +370,7 @@ mod std_support {
 
     impl<'v> Cast<'v> {
         #[inline]
-        pub(super) fn into_str(self) -> Option<Cow<'v, str>> {
+        pub(in crate::internal) fn into_str(self) -> Option<Cow<'v, str>> {
             match self {
                 Cast::Str(value) => Some(value.into()),
                 Cast::String(value) => Some(value.into()),

--- a/src/internal/cast/primitive.rs
+++ b/src/internal/cast/primitive.rs
@@ -8,7 +8,7 @@ use crate::std::string::String;
 
 use crate::internal::Internal;
 
-pub(super) fn from_any<'v, T: ?Sized + 'static>(value: &'v T) -> Option<Internal<'v>> {
+pub(in crate::internal) fn from_any<'v, T: ?Sized + 'static>(value: &'v T) -> Option<Internal<'v>> {
     // NOTE: The casts for unsized values (str) are dubious here. To really do this properly
     // we need https://github.com/rust-lang/rust/issues/81513
     // NOTE: With some kind of const `Any::is<T>` we could do all this at compile-time

--- a/src/internal/fmt.rs
+++ b/src/internal/fmt.rs
@@ -413,12 +413,12 @@ mod tests {
     fn fmt_debug() {
         assert_eq!(
             format!("{:?}", "a string"),
-            format!("{:?}", "a string".into_value_bag()),
+            format!("{:?}", "a string".into_value_bag().by_ref()),
         );
 
         assert_eq!(
             format!("{:04?}", 42u64),
-            format!("{:04?}", 42u64.into_value_bag()),
+            format!("{:04?}", 42u64.into_value_bag().by_ref()),
         );
     }
 
@@ -427,12 +427,12 @@ mod tests {
     fn fmt_display() {
         assert_eq!(
             format!("{}", "a string"),
-            format!("{}", "a string".into_value_bag()),
+            format!("{}", "a string".into_value_bag().by_ref()),
         );
 
         assert_eq!(
             format!("{:04}", 42u64),
-            format!("{:04}", 42u64.into_value_bag()),
+            format!("{:04}", 42u64.into_value_bag().by_ref()),
         );
     }
 }

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -22,7 +22,7 @@ pub(super) mod sval;
 // of a `TypeId` instead of using `Option<T>`, because `TypeId` doesn't
 // have a niche value
 /// A container for a structured value for a specific kind of visitor.
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub(super) enum Internal<'v> {
     /// A signed integer.
     Signed(i64),
@@ -81,7 +81,13 @@ pub(super) enum Internal<'v> {
 /// The internal serialization contract.
 pub(super) trait InternalVisitor<'v> {
     fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error>;
+    fn borrowed_debug(&mut self, v: &'v dyn fmt::Debug) -> Result<(), Error> {
+        self.debug(v)
+    }
     fn display(&mut self, v: &dyn fmt::Display) -> Result<(), Error>;
+    fn borrowed_display(&mut self, v: &'v dyn fmt::Display) -> Result<(), Error> {
+        self.display(v)
+    }
 
     fn u64(&mut self, v: u64) -> Result<(), Error>;
     fn i64(&mut self, v: i64) -> Result<(), Error>;
@@ -120,6 +126,106 @@ pub(super) trait InternalVisitor<'v> {
 
     #[cfg(feature = "serde1")]
     fn serde1(&mut self, v: &dyn serde::v1::Serialize) -> Result<(), Error>;
+    #[cfg(feature = "serde1")]
+    fn borrowed_serde1(&mut self, v: &'v dyn serde::v1::Serialize) -> Result<(), Error> {
+        self.serde1(v)
+    }
+}
+
+impl<'a, 'v, V: InternalVisitor<'v> + ?Sized> InternalVisitor<'v> for &'a mut V {
+    fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error> {
+        (**self).debug(v)
+    }
+
+    fn borrowed_debug(&mut self, v: &'v dyn fmt::Debug) -> Result<(), Error> {
+        (**self).borrowed_debug(v)
+    }
+
+    fn display(&mut self, v: &dyn fmt::Display) -> Result<(), Error> {
+        (**self).display(v)
+    }
+
+    fn borrowed_display(&mut self, v: &'v dyn fmt::Display) -> Result<(), Error> {
+        (**self).borrowed_display(v)
+    }
+
+    fn u64(&mut self, v: u64) -> Result<(), Error> {
+        (**self).u64(v)
+    }
+
+    fn i64(&mut self, v: i64) -> Result<(), Error> {
+        (**self).i64(v)
+    }
+
+    fn u128(&mut self, v: &u128) -> Result<(), Error> {
+        (**self).u128(v)
+    }
+
+    fn borrowed_u128(&mut self, v: &'v u128) -> Result<(), Error> {
+        (**self).borrowed_u128(v)
+    }
+
+    fn i128(&mut self, v: &i128) -> Result<(), Error> {
+        (**self).i128(v)
+    }
+
+    fn borrowed_i128(&mut self, v: &'v i128) -> Result<(), Error> {
+        (**self).borrowed_i128(v)
+    }
+
+    fn f64(&mut self, v: f64) -> Result<(), Error> {
+        (**self).f64(v)
+    }
+
+    fn bool(&mut self, v: bool) -> Result<(), Error> {
+        (**self).bool(v)
+    }
+
+    fn char(&mut self, v: char) -> Result<(), Error> {
+        (**self).char(v)
+    }
+
+    fn str(&mut self, v: &str) -> Result<(), Error> {
+        (**self).str(v)
+    }
+
+    fn borrowed_str(&mut self, v: &'v str) -> Result<(), Error> {
+        (**self).borrowed_str(v)
+    }
+
+    fn none(&mut self) -> Result<(), Error> {
+        (**self).none()
+    }
+
+    #[cfg(feature = "error")]
+    fn error(&mut self, v: &(dyn error::Error + 'static)) -> Result<(), Error> {
+        (**self).error(v)
+    }
+
+    #[cfg(feature = "error")]
+    fn borrowed_error(&mut self, v: &'v (dyn error::Error + 'static)) -> Result<(), Error> {
+        (**self).borrowed_error(v)
+    }
+
+    #[cfg(feature = "sval2")]
+    fn sval2(&mut self, v: &dyn sval::v2::Value) -> Result<(), Error> {
+        (**self).sval2(v)
+    }
+
+    #[cfg(feature = "sval2")]
+    fn borrowed_sval2(&mut self, v: &'v dyn sval::v2::Value) -> Result<(), Error> {
+        (**self).borrowed_sval2(v)
+    }
+
+    #[cfg(feature = "serde1")]
+    fn serde1(&mut self, v: &dyn serde::v1::Serialize) -> Result<(), Error> {
+        (**self).serde1(v)
+    }
+
+    #[cfg(feature = "serde1")]
+    fn borrowed_serde1(&mut self, v: &'v dyn serde::v1::Serialize) -> Result<(), Error> {
+        (**self).borrowed_serde1(v)
+    }
 }
 
 impl<'v> ValueBag<'v> {
@@ -135,29 +241,67 @@ impl<'v> ValueBag<'v> {
 
     /// Visit the value using an internal visitor.
     #[inline]
-    pub(super) fn internal_visit(
-        &self,
-        visitor: &mut dyn InternalVisitor<'v>,
-    ) -> Result<(), Error> {
+    pub(super) fn internal_visit(&self, visitor: impl InternalVisitor<'v>) -> Result<(), Error> {
         self.inner.internal_visit(visitor)
     }
 }
 
 impl<'v> Internal<'v> {
     #[inline]
-    pub(super) fn internal_visit(self, visitor: &mut dyn InternalVisitor<'v>) -> Result<(), Error> {
+    pub(super) fn by_ref<'u>(&'u self) -> Internal<'u> {
         match self {
-            Internal::Signed(value) => visitor.i64(value),
-            Internal::Unsigned(value) => visitor.u64(value),
+            Internal::Signed(value) => Internal::Signed(*value),
+            Internal::Unsigned(value) => Internal::Unsigned(*value),
+            Internal::BigSigned(value) => Internal::BigSigned(*value),
+            Internal::BigUnsigned(value) => Internal::BigUnsigned(*value),
+            Internal::Float(value) => Internal::Float(*value),
+            Internal::Bool(value) => Internal::Bool(*value),
+            Internal::Char(value) => Internal::Char(*value),
+            Internal::Str(value) => Internal::Str(*value),
+            Internal::None => Internal::None,
+
+            Internal::Fill(value) => Internal::Fill(*value),
+
+            Internal::AnonDebug(value) => Internal::AnonDebug(*value),
+            Internal::Debug(value) => Internal::Debug(*value),
+
+            Internal::AnonDisplay(value) => Internal::AnonDisplay(*value),
+            Internal::Display(value) => Internal::Display(*value),
+
+            #[cfg(feature = "error")]
+            Internal::AnonError(value) => Internal::AnonError(*value),
+            #[cfg(feature = "error")]
+            Internal::Error(value) => Internal::Error(*value),
+
+            #[cfg(feature = "sval2")]
+            Internal::AnonSval2(value) => Internal::AnonSval2(*value),
+            #[cfg(feature = "sval2")]
+            Internal::Sval2(value) => Internal::Sval2(*value),
+
+            #[cfg(feature = "serde1")]
+            Internal::AnonSerde1(value) => Internal::AnonSerde1(*value),
+            #[cfg(feature = "serde1")]
+            Internal::Serde1(value) => Internal::Serde1(*value),
+        }
+    }
+
+    #[inline]
+    pub(super) fn internal_visit(
+        &self,
+        mut visitor: impl InternalVisitor<'v>,
+    ) -> Result<(), Error> {
+        match self {
+            Internal::Signed(value) => visitor.i64(*value),
+            Internal::Unsigned(value) => visitor.u64(*value),
             Internal::BigSigned(value) => visitor.i128(value),
             Internal::BigUnsigned(value) => visitor.u128(value),
-            Internal::Float(value) => visitor.f64(value),
-            Internal::Bool(value) => visitor.bool(value),
-            Internal::Char(value) => visitor.char(value),
+            Internal::Float(value) => visitor.f64(*value),
+            Internal::Bool(value) => visitor.bool(*value),
+            Internal::Char(value) => visitor.char(*value),
             Internal::Str(value) => visitor.borrowed_str(value),
             Internal::None => visitor.none(),
 
-            Internal::Fill(value) => value.fill(Slot::new(visitor)),
+            Internal::Fill(value) => value.fill(Slot::new(&mut visitor)),
 
             Internal::AnonDebug(value) => visitor.debug(value),
             Internal::Debug(value) => visitor.debug(value.as_super()),
@@ -166,19 +310,19 @@ impl<'v> Internal<'v> {
             Internal::Display(value) => visitor.display(value.as_super()),
 
             #[cfg(feature = "error")]
-            Internal::AnonError(value) => visitor.borrowed_error(value),
+            Internal::AnonError(value) => visitor.borrowed_error(*value),
             #[cfg(feature = "error")]
             Internal::Error(value) => visitor.borrowed_error(value.as_super()),
 
             #[cfg(feature = "sval2")]
-            Internal::AnonSval2(value) => visitor.borrowed_sval2(value),
+            Internal::AnonSval2(value) => visitor.borrowed_sval2(*value),
             #[cfg(feature = "sval2")]
             Internal::Sval2(value) => visitor.borrowed_sval2(value.as_super()),
 
             #[cfg(feature = "serde1")]
-            Internal::AnonSerde1(value) => visitor.serde1(value),
+            Internal::AnonSerde1(value) => visitor.borrowed_serde1(*value),
             #[cfg(feature = "serde1")]
-            Internal::Serde1(value) => visitor.serde1(value.as_super()),
+            Internal::Serde1(value) => visitor.borrowed_serde1(value.as_super()),
         }
     }
 }

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -8,22 +8,22 @@ use crate::{
     Error, ValueBag,
 };
 
-pub(super) mod cast;
+pub(crate) mod cast;
 #[cfg(feature = "error")]
-pub(super) mod error;
-pub(super) mod fill;
-pub(super) mod fmt;
+pub(crate) mod error;
+pub(crate) mod fill;
+pub(crate) mod fmt;
 #[cfg(feature = "serde1")]
-pub(super) mod serde;
+pub(crate) mod serde;
 #[cfg(feature = "sval2")]
-pub(super) mod sval;
+pub(crate) mod sval;
 
 // NOTE: It takes less space to have separate variants for the presence
 // of a `TypeId` instead of using `Option<T>`, because `TypeId` doesn't
 // have a niche value
 /// A container for a structured value for a specific kind of visitor.
 #[derive(Clone)]
-pub(super) enum Internal<'v> {
+pub(crate) enum Internal<'v> {
     /// A signed integer.
     Signed(i64),
     /// An unsigned integer.
@@ -79,7 +79,7 @@ pub(super) enum Internal<'v> {
 }
 
 /// The internal serialization contract.
-pub(super) trait InternalVisitor<'v> {
+pub(crate) trait InternalVisitor<'v> {
     fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error>;
     fn borrowed_debug(&mut self, v: &'v dyn fmt::Debug) -> Result<(), Error> {
         self.debug(v)
@@ -230,7 +230,7 @@ impl<'a, 'v, V: InternalVisitor<'v> + ?Sized> InternalVisitor<'v> for &'a mut V 
 
 impl<'v> ValueBag<'v> {
     /// Get a value from an internal primitive.
-    pub(super) fn from_internal<T>(value: T) -> Self
+    pub(crate) fn from_internal<T>(value: T) -> Self
     where
         T: Into<Internal<'v>>,
     {
@@ -241,14 +241,14 @@ impl<'v> ValueBag<'v> {
 
     /// Visit the value using an internal visitor.
     #[inline]
-    pub(super) fn internal_visit(&self, visitor: impl InternalVisitor<'v>) -> Result<(), Error> {
+    pub(crate) fn internal_visit(&self, visitor: impl InternalVisitor<'v>) -> Result<(), Error> {
         self.inner.internal_visit(visitor)
     }
 }
 
 impl<'v> Internal<'v> {
     #[inline]
-    pub(super) fn by_ref<'u>(&'u self) -> Internal<'u> {
+    pub(crate) fn by_ref<'u>(&'u self) -> Internal<'u> {
         match self {
             Internal::Signed(value) => Internal::Signed(*value),
             Internal::Unsigned(value) => Internal::Unsigned(*value),
@@ -286,7 +286,7 @@ impl<'v> Internal<'v> {
     }
 
     #[inline]
-    pub(super) fn internal_visit(
+    pub(crate) fn internal_visit(
         &self,
         mut visitor: impl InternalVisitor<'v>,
     ) -> Result<(), Error> {

--- a/src/internal/serde/v1.rs
+++ b/src/internal/serde/v1.rs
@@ -605,6 +605,7 @@ mod tests {
             assert_eq!(
                 "a string",
                 ValueBag::capture_serde1(&"a string".to_owned())
+                    .by_ref()
                     .to_str()
                     .expect("invalid value")
             );

--- a/src/internal/sval/v2.rs
+++ b/src/internal/sval/v2.rs
@@ -499,6 +499,7 @@ mod tests {
             assert_eq!(
                 "a string",
                 ValueBag::capture_sval2(&"a string".to_owned())
+                    .by_ref()
                     .to_str()
                     .expect("invalid value")
             );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,7 +374,9 @@ impl<'v> ValueBag<'v> {
     /// Get a `ValueBag` from a reference to a `ValueBag`.
     #[inline]
     pub fn by_ref<'u>(&'u self) -> ValueBag<'u> {
-        ValueBag { inner: self.inner }
+        ValueBag {
+            inner: self.inner.by_ref(),
+        }
     }
 }
 


### PR DESCRIPTION
This PR removes the `Copy` bound from `Internal` so we can add owned values to it. It's not public API so there's no breakage in doing this. I've also made the internal visitor API a little more general.