### PR TITLE
Support storing 128bit numbers inline

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
           - windows-latest
     steps:
       - name: Checkout sources

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ members = [
 ]
 
 [features]
+# Store 128bit numbers inline instead of as references
+# This may increase the size of `ValueBag` on some platforms
+inline-i128 = []
+
 # Use the standard library
 std = [
     "value-bag-sval2?/std",

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -61,6 +61,22 @@ impl<'v> From<&'v i128> for ValueBag<'v> {
     }
 }
 
+#[cfg(feature = "inline-i128")]
+impl<'v> From<u128> for ValueBag<'v> {
+    #[inline]
+    fn from(value: u128) -> Self {
+        ValueBag::from_internal(value)
+    }
+}
+
+#[cfg(feature = "inline-i128")]
+impl<'v> From<i128> for ValueBag<'v> {
+    #[inline]
+    fn from(value: i128) -> Self {
+        ValueBag::from_internal(value)
+    }
+}
+
 #[cfg(feature = "std")]
 mod std_support {
     use super::*;
@@ -131,5 +147,17 @@ mod tests {
             ().into_value_bag().by_ref().to_test_token(),
             TestToken::None
         );
+
+        #[cfg(feature = "inline-i128")]
+        {
+            assert_eq!(
+                42u128.into_value_bag().by_ref().to_test_token(),
+                TestToken::U128(42)
+            );
+            assert_eq!(
+                42i128.into_value_bag().by_ref().to_test_token(),
+                TestToken::I128(42)
+            );
+        }
     }
 }

--- a/src/internal/cast/mod.rs
+++ b/src/internal/cast/mod.rs
@@ -226,7 +226,13 @@ impl<'v> Internal<'v> {
         match &self {
             Internal::Signed(value) => Cast::Signed(*value),
             Internal::Unsigned(value) => Cast::Unsigned(*value),
+            #[cfg(feature = "inline-i128")]
+            Internal::BigSigned(value) => Cast::BigSigned(*value),
+            #[cfg(not(feature = "inline-i128"))]
             Internal::BigSigned(value) => Cast::BigSigned(**value),
+            #[cfg(feature = "inline-i128")]
+            Internal::BigUnsigned(value) => Cast::BigUnsigned(*value),
+            #[cfg(not(feature = "inline-i128"))]
             Internal::BigUnsigned(value) => Cast::BigUnsigned(**value),
             Internal::Float(value) => Cast::Float(*value),
             Internal::Bool(value) => Cast::Bool(*value),

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -29,9 +29,15 @@ pub(crate) enum Internal<'v> {
     /// An unsigned integer.
     Unsigned(u64),
     /// An extra large signed integer.
+    #[cfg(not(feature = "inline-i128"))]
     BigSigned(&'v i128),
+    #[cfg(feature = "inline-i128")]
+    BigSigned(i128),
     /// An extra large unsigned integer.
+    #[cfg(not(feature = "inline-i128"))]
     BigUnsigned(&'v u128),
+    #[cfg(feature = "inline-i128")]
+    BigUnsigned(u128),
     /// A floating point number.
     Float(f64),
     /// A boolean value.
@@ -477,6 +483,21 @@ impl<'v> From<&'v u64> for Internal<'v> {
 impl<'v> From<&'v u128> for Internal<'v> {
     #[inline]
     fn from(v: &'v u128) -> Self {
+        #[cfg(feature = "inline-i128")]
+        {
+            Internal::BigUnsigned(*v)
+        }
+        #[cfg(not(feature = "inline-i128"))]
+        {
+            Internal::BigUnsigned(v)
+        }
+    }
+}
+
+#[cfg(feature = "inline-i128")]
+impl<'v> From<u128> for Internal<'v> {
+    #[inline]
+    fn from(v: u128) -> Self {
         Internal::BigUnsigned(v)
     }
 }
@@ -519,6 +540,21 @@ impl<'v> From<&'v i64> for Internal<'v> {
 impl<'v> From<&'v i128> for Internal<'v> {
     #[inline]
     fn from(v: &'v i128) -> Self {
+        #[cfg(feature = "inline-i128")]
+        {
+            Internal::BigSigned(*v)
+        }
+        #[cfg(not(feature = "inline-i128"))]
+        {
+            Internal::BigSigned(v)
+        }
+    }
+}
+
+#[cfg(feature = "inline-i128")]
+impl<'v> From<i128> for Internal<'v> {
+    #[inline]
+    fn from(v: i128) -> Self {
         Internal::BigSigned(v)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,10 +385,15 @@ mod tests {
     use super::*;
     use crate::std::mem;
 
+    #[cfg(feature = "inline-i128")]
+    const SIZE_LIMIT_U64: usize = 4;
+    #[cfg(not(feature = "inline-i128"))]
+    const SIZE_LIMIT_U64: usize = 3;
+
     #[test]
     fn value_bag_size() {
         let size = mem::size_of::<ValueBag<'_>>();
-        let limit = mem::size_of::<u64>() * 3;
+        let limit = mem::size_of::<u64>() * SIZE_LIMIT_U64;
 
         if size > limit {
             panic!(


### PR DESCRIPTION
Closes #40 

This PR adds an `inline-i128` feature that is off by default, but allows storing 128bit numbers inline instead of by reference. On platforms where 128bit numbers are 16byte aligned (like aarch64), this increases the size of `ValueBag` by 8bytes.