### PR TITLE
Start sketching out an owned value

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,7 +41,7 @@ jobs:
         run: cargo install cargo-hack
 
       - name: Powerset
-        run: cargo hack check --each-feature --exclude-features std,test,error -Z avoid-dev-deps --target thumbv6m-none-eabi
+        run: cargo hack check --each-feature --exclude-features std,test,error,owned -Z avoid-dev-deps --target thumbv6m-none-eabi
 
   nodeps:
     name: Build (no dev deps)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [package.metadata.docs.rs]
-features = ["std", "error", "sval", "serde", "test"]
+features = ["std", "error", "sval", "serde", "test", "owned"]
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,12 @@ alloc = [
     "value-bag-serde1?/alloc",
 ]
 
+# Support owned values
+owned = [
+    "alloc",
+    "value-bag-serde1?/owned",
+]
+
 # Add support for `sval`
 sval = ["sval2"]
 sval2 = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ inline-i128 = []
 
 # Use the standard library
 std = [
+    "alloc",
     "value-bag-sval2?/std",
     "value-bag-serde1?/std",
 ]

--- a/README.md
+++ b/README.md
@@ -113,4 +113,5 @@ The `value-bag` crate is no-std by default, and offers the following Cargo featu
     - `sval2`: Enable support for the stable `2.x.x` version of `sval`.
 - `serde`: Enable support for using the [`serde`](https://github.com/serde-rs/serde) serialization framework for inspecting `ValueBag`s by implementing `serde::Serialize`. Implies `std` and `serde1`.
     - `serde1`: Enable support for the stable `1.x.x` version of `serde`.
+- `owned`: Add support for buffering `ValueBag`s into an owned `Send + Sync` variant.
 - `test`: Add test helpers for inspecting the shape of the value inside a `ValueBag`.

--- a/benches/owned.rs
+++ b/benches/owned.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "alloc")]
+#![cfg(feature = "owned")]
 #![feature(test)]
 
 extern crate test;

--- a/benches/owned.rs
+++ b/benches/owned.rs
@@ -25,3 +25,66 @@ fn display_to_owned(b: &mut test::Bencher) {
 
     b.iter(|| bag.to_owned());
 }
+
+#[cfg(feature = "serde1")]
+#[bench]
+fn serde1_to_owned(b: &mut test::Bencher) {
+    use value_bag_serde1::lib::ser::{Serialize, SerializeStruct, Serializer};
+
+    pub struct MyData<'a> {
+        a: i32,
+        b: &'a str,
+    }
+
+    impl<'a> Serialize for MyData<'a> {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            let mut serializer = serializer.serialize_struct("MyData", 2)?;
+
+            serializer.serialize_field("a", &self.a)?;
+            serializer.serialize_field("b", &self.b)?;
+
+            serializer.end()
+        }
+    }
+
+    let bag = ValueBag::from_serde1(&MyData {
+        a: 42,
+        b: "a string",
+    });
+
+    b.iter(|| bag.to_owned());
+}
+
+#[cfg(feature = "sval2")]
+#[bench]
+fn sval2_to_owned(b: &mut test::Bencher) {
+    use value_bag_sval2::lib::{Label, Result, Stream, Value};
+
+    pub struct MyData<'a> {
+        a: i32,
+        b: &'a str,
+    }
+
+    impl<'a> Value for MyData<'a> {
+        fn stream<'sval, S: Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> Result {
+            stream.record_begin(None, Some(&Label::new("MyData")), None, Some(2))?;
+
+            stream.record_value_begin(None, &Label::new("a"))?;
+            stream.value(&self.a)?;
+            stream.record_value_end(None, &Label::new("a"))?;
+
+            stream.record_value_begin(None, &Label::new("b"))?;
+            stream.value(&self.b)?;
+            stream.record_value_end(None, &Label::new("b"))?;
+
+            stream.record_end(None, Some(&Label::new("MyData")), None)
+        }
+    }
+
+    let bag = ValueBag::from_sval2(&MyData {
+        a: 42,
+        b: "a string",
+    });
+
+    b.iter(|| bag.to_owned());
+}

--- a/benches/owned.rs
+++ b/benches/owned.rs
@@ -1,0 +1,27 @@
+#![cfg(feature = "alloc")]
+#![feature(test)]
+
+extern crate test;
+
+use value_bag::ValueBag;
+
+#[bench]
+fn u8_to_owned(b: &mut test::Bencher) {
+    let bag = ValueBag::from(1u8);
+
+    b.iter(|| bag.to_owned());
+}
+
+#[bench]
+fn str_to_owned(b: &mut test::Bencher) {
+    let bag = ValueBag::from("a string");
+
+    b.iter(|| bag.to_owned());
+}
+
+#[bench]
+fn display_to_owned(b: &mut test::Bencher) {
+    let bag = ValueBag::from_display(&42);
+
+    b.iter(|| bag.to_owned());
+}

--- a/meta/serde1/Cargo.toml
+++ b/meta/serde1/Cargo.toml
@@ -36,6 +36,10 @@ default-features = false
 version = "1"
 default-features = false
 
+[dependencies.serde_buf]
+version = "0.1"
+default-features = false
+
 [dependencies.serde_json]
 version = "1"
 optional = true

--- a/meta/serde1/Cargo.toml
+++ b/meta/serde1/Cargo.toml
@@ -14,6 +14,10 @@ std = [
 
 alloc = []
 
+owned = [
+    "serde_buf"
+]
+
 json = [
     "serde_json",
 ]
@@ -39,6 +43,7 @@ default-features = false
 [dependencies.serde_buf]
 version = "0.1"
 default-features = false
+optional = true
 
 [dependencies.serde_json]
 version = "1"

--- a/meta/serde1/src/lib.rs
+++ b/meta/serde1/src/lib.rs
@@ -6,8 +6,10 @@ Implementation detail for `value-bag`; it should not be depended on directly.
 
 pub use erased_serde as erased;
 pub use serde as lib;
-pub use serde_buf as buf;
 pub use serde_fmt as fmt;
+
+#[cfg(feature = "owned")]
+pub use serde_buf as buf;
 
 #[cfg(feature = "json")]
 pub use serde_json as json;

--- a/meta/serde1/src/lib.rs
+++ b/meta/serde1/src/lib.rs
@@ -6,6 +6,7 @@ Implementation detail for `value-bag`; it should not be depended on directly.
 
 pub use erased_serde as erased;
 pub use serde as lib;
+pub use serde_buf as buf;
 pub use serde_fmt as fmt;
 
 #[cfg(feature = "json")]

--- a/src/fill.rs
+++ b/src/fill.rs
@@ -194,4 +194,11 @@ mod tests {
             )
         );
     }
+
+    #[test]
+    #[cfg(feature = "owned")]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn fill_to_owned() {
+        todo!()
+    }
 }

--- a/src/fill.rs
+++ b/src/fill.rs
@@ -194,11 +194,4 @@ mod tests {
             )
         );
     }
-
-    #[test]
-    #[cfg(feature = "owned")]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn fill_to_owned() {
-        todo!()
-    }
 }

--- a/src/internal/error.rs
+++ b/src/internal/error.rs
@@ -94,7 +94,7 @@ impl Error for OwnedError {
     }
 }
 
-pub(crate) fn buffer_error(err: &(dyn error::Error + 'static)) -> OwnedError {
+pub(crate) fn buffer(err: &(dyn error::Error + 'static)) -> OwnedError {
     OwnedError {
         display: err.to_string().into(),
         source: err.source().map(buffer_error).map(Box::new),

--- a/src/internal/error.rs
+++ b/src/internal/error.rs
@@ -159,11 +159,4 @@ mod tests {
             .visit(TestVisit::default())
             .expect("failed to visit value");
     }
-
-    #[test]
-    #[cfg(feature = "owned")]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn error_to_owned() {
-        todo!()
-    }
 }

--- a/src/internal/error.rs
+++ b/src/internal/error.rs
@@ -97,7 +97,7 @@ impl Error for OwnedError {
 pub(crate) fn buffer(err: &(dyn error::Error + 'static)) -> OwnedError {
     OwnedError {
         display: err.to_string().into(),
-        source: err.source().map(buffer_error).map(Box::new),
+        source: err.source().map(buffer).map(Box::new),
     }
 }
 

--- a/src/internal/fmt.rs
+++ b/src/internal/fmt.rs
@@ -323,25 +323,24 @@ impl<'v> Display for ValueBag<'v> {
     }
 }
 
-#[cfg(feature = "alloc")]
-impl fmt::Debug for crate::OwnedValueBag {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(&self.by_ref(), f)
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl fmt::Display for crate::OwnedValueBag {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&self.by_ref(), f)
-    }
-}
-
-#[cfg(feature = "alloc")]
+#[cfg(feature = "owned")]
 pub(crate) mod owned {
-    use super::*;
+    use crate::std::{boxed::Box, fmt, string::ToString};
 
-    use crate::std::{boxed::Box, string::ToString};
+    impl fmt::Debug for crate::OwnedValueBag {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fmt::Debug::fmt(&self.by_ref(), f)
+        }
+    }
+
+    impl fmt::Display for crate::OwnedValueBag {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fmt::Display::fmt(&self.by_ref(), f)
+        }
+    }
+
+    #[derive(Clone)]
+    pub(crate) struct OwnedFmt(Box<str>);
 
     pub(crate) fn buffer_debug(v: impl fmt::Debug) -> OwnedFmt {
         OwnedFmt(format!("{:?}", v).into())
@@ -350,9 +349,6 @@ pub(crate) mod owned {
     pub(crate) fn buffer_display(v: impl fmt::Display) -> OwnedFmt {
         OwnedFmt(v.to_string().into())
     }
-
-    #[derive(Clone)]
-    pub(crate) struct OwnedFmt(Box<str>);
 
     impl fmt::Debug for OwnedFmt {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -478,5 +474,12 @@ mod tests {
             format!("{:04}", 42u64),
             format!("{:04}", 42u64.into_value_bag().by_ref()),
         );
+    }
+
+    #[test]
+    #[cfg(feature = "owned")]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn fmt_to_owned() {
+        todo!()
     }
 }

--- a/src/internal/fmt.rs
+++ b/src/internal/fmt.rs
@@ -326,14 +326,44 @@ impl<'v> Display for ValueBag<'v> {
 #[cfg(feature = "alloc")]
 impl fmt::Debug for crate::OwnedValueBag {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(&self.to_value(), f)
+        fmt::Debug::fmt(&self.by_ref(), f)
     }
 }
 
 #[cfg(feature = "alloc")]
 impl fmt::Display for crate::OwnedValueBag {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&self.to_value(), f)
+        fmt::Display::fmt(&self.by_ref(), f)
+    }
+}
+
+#[cfg(feature = "alloc")]
+pub(crate) mod owned {
+    use super::*;
+
+    use crate::std::{boxed::Box, string::ToString};
+
+    pub(crate) fn buffer_debug(v: impl fmt::Debug) -> OwnedFmt {
+        OwnedFmt(format!("{:?}", v).into())
+    }
+
+    pub(crate) fn buffer_display(v: impl fmt::Display) -> OwnedFmt {
+        OwnedFmt(v.to_string().into())
+    }
+
+    #[derive(Clone)]
+    pub(crate) struct OwnedFmt(Box<str>);
+
+    impl fmt::Debug for OwnedFmt {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fmt::Display::fmt(self, f)
+        }
+    }
+
+    impl fmt::Display for OwnedFmt {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fmt::Display::fmt(&self.0, f)
+        }
     }
 }
 

--- a/src/internal/fmt.rs
+++ b/src/internal/fmt.rs
@@ -475,11 +475,4 @@ mod tests {
             format!("{:04}", 42u64.into_value_bag().by_ref()),
         );
     }
-
-    #[test]
-    #[cfg(feature = "owned")]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn fmt_to_owned() {
-        todo!()
-    }
 }

--- a/src/internal/fmt.rs
+++ b/src/internal/fmt.rs
@@ -323,6 +323,20 @@ impl<'v> Display for ValueBag<'v> {
     }
 }
 
+#[cfg(feature = "alloc")]
+impl fmt::Debug for crate::OwnedValueBag {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.to_value(), f)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl fmt::Display for crate::OwnedValueBag {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.to_value(), f)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(target_arch = "wasm32")]

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -18,7 +18,7 @@ pub(crate) mod serde;
 #[cfg(feature = "sval2")]
 pub(crate) mod sval;
 
-#[cfg(feature = "alloc")]
+#[cfg(feature = "owned")]
 pub(crate) mod owned;
 
 // NOTE: It takes less space to have separate variants for the presence

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -18,6 +18,9 @@ pub(crate) mod serde;
 #[cfg(feature = "sval2")]
 pub(crate) mod sval;
 
+#[cfg(feature = "alloc")]
+pub(crate) mod owned;
+
 // NOTE: It takes less space to have separate variants for the presence
 // of a `TypeId` instead of using `Option<T>`, because `TypeId` doesn't
 // have a niche value
@@ -603,31 +606,6 @@ where
         Internal::Str(*v)
     }
 }
-
-#[cfg(feature = "alloc")]
-mod alloc_support {
-    use crate::std::boxed::Box;
-
-    pub(crate) enum OwnedInternal {
-        /// An extra large signed integer.
-        BigSigned(i128),
-        /// An extra large unsigned integer.
-        BigUnsigned(u128),
-        /// A floating point number.
-        Float(f64),
-        /// A boolean value.
-        Bool(bool),
-        /// A UTF8 codepoint.
-        Char(char),
-        /// A UTF8 string.
-        Str(Box<str>),
-        /// An empty value.
-        None,
-    }
-}
-
-#[cfg(feature = "alloc")]
-pub(crate) use alloc_support::*;
 
 #[cfg(feature = "std")]
 mod std_support {

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -604,6 +604,31 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
+mod alloc_support {
+    use crate::std::boxed::Box;
+
+    pub(crate) enum OwnedInternal {
+        /// An extra large signed integer.
+        BigSigned(i128),
+        /// An extra large unsigned integer.
+        BigUnsigned(u128),
+        /// A floating point number.
+        Float(f64),
+        /// A boolean value.
+        Bool(bool),
+        /// A UTF8 codepoint.
+        Char(char),
+        /// A UTF8 string.
+        Str(Box<str>),
+        /// An empty value.
+        None,
+    }
+}
+
+#[cfg(feature = "alloc")]
+pub(crate) use alloc_support::*;
+
 #[cfg(feature = "std")]
 mod std_support {
     use super::*;

--- a/src/internal/owned.rs
+++ b/src/internal/owned.rs
@@ -27,10 +27,10 @@ pub(crate) enum OwnedInternal {
     Display(internal::fmt::owned::OwnedFmt),
 
     #[cfg(feature = "error")]
-    Error(internal::error::OwnedError),
+    Error(internal::error::owned::OwnedError),
 
     #[cfg(feature = "serde1")]
-    Serde1(internal::serde::v1::OwnedSerialize),
+    Serde1(internal::serde::v1::owned::OwnedSerialize),
 
     #[cfg(feature = "sval2")]
     Sval2(internal::sval::v2::owned::OwnedValue),
@@ -53,17 +53,17 @@ impl OwnedInternal {
             OwnedInternal::Str(v) => Internal::Str(v),
             OwnedInternal::None => Internal::None,
 
-            OwnedInternal::Debug(v) => Internal::Debug(v),
-            OwnedInternal::Display(v) => Internal::Display(v),
+            OwnedInternal::Debug(v) => Internal::AnonDebug(v),
+            OwnedInternal::Display(v) => Internal::AnonDisplay(v),
 
             #[cfg(feature = "error")]
-            OwnedInternal::Error(v) => Internal::Error(v),
+            OwnedInternal::Error(v) => Internal::AnonError(v),
 
             #[cfg(feature = "serde1")]
-            OwnedInternal::Serde1(v) => Internal::Serde1(v),
+            OwnedInternal::Serde1(v) => Internal::AnonSerde1(v),
 
             #[cfg(feature = "sval2")]
-            OwnedInternal::Sval2(v) => Internal::Sval2(v),
+            OwnedInternal::Sval2(v) => Internal::AnonSval2(v),
         }
     }
 }
@@ -130,7 +130,7 @@ impl<'v> Internal<'v> {
 
             #[cfg(feature = "error")]
             fn error(&mut self, v: &(dyn internal::error::Error + 'static)) -> Result<(), Error> {
-                self.0 = OwnedInternal::Error(internal::error::buffer(v));
+                self.0 = OwnedInternal::Error(internal::error::owned::buffer(v));
                 Ok(())
             }
 
@@ -142,7 +142,7 @@ impl<'v> Internal<'v> {
 
             #[cfg(feature = "serde1")]
             fn serde1(&mut self, v: &dyn internal::serde::v1::Serialize) -> Result<(), Error> {
-                self.0 = OwnedInternal::Serde1(internal::serde::v1::buffer(v));
+                self.0 = OwnedInternal::Serde1(internal::serde::v1::owned::buffer(v));
                 Ok(())
             }
         }

--- a/src/internal/owned.rs
+++ b/src/internal/owned.rs
@@ -28,6 +28,12 @@ pub(crate) enum OwnedInternal {
 
     #[cfg(feature = "error")]
     Error(internal::error::OwnedError),
+
+    #[cfg(feature = "serde1")]
+    Serde1(internal::serde::v1::OwnedSerialize),
+
+    #[cfg(feature = "sval2")]
+    Sval2(internal::sval::v2::owned::OwnedValue),
 }
 
 impl OwnedInternal {
@@ -52,6 +58,12 @@ impl OwnedInternal {
 
             #[cfg(feature = "error")]
             OwnedInternal::Error(v) => Internal::Error(v),
+
+            #[cfg(feature = "serde1")]
+            OwnedInternal::Serde1(v) => Internal::Serde1(v),
+
+            #[cfg(feature = "sval2")]
+            OwnedInternal::Sval2(v) => Internal::Sval2(v),
         }
     }
 }
@@ -118,18 +130,20 @@ impl<'v> Internal<'v> {
 
             #[cfg(feature = "error")]
             fn error(&mut self, v: &(dyn internal::error::Error + 'static)) -> Result<(), Error> {
-                self.0 = OwnedInternal::Error(internal::error::buffer_error(v));
+                self.0 = OwnedInternal::Error(internal::error::buffer(v));
                 Ok(())
             }
 
             #[cfg(feature = "sval2")]
             fn sval2(&mut self, v: &dyn internal::sval::v2::Value) -> Result<(), Error> {
-                todo!()
+                self.0 = OwnedInternal::Sval2(internal::sval::v2::owned::buffer(v));
+                Ok(())
             }
 
             #[cfg(feature = "serde1")]
             fn serde1(&mut self, v: &dyn internal::serde::v1::Serialize) -> Result<(), Error> {
-                todo!()
+                self.0 = OwnedInternal::Serde1(internal::serde::v1::buffer(v));
+                Ok(())
             }
         }
 

--- a/src/internal/owned.rs
+++ b/src/internal/owned.rs
@@ -1,0 +1,142 @@
+use crate::{
+    internal::{self, Internal, InternalVisitor},
+    std::boxed::Box,
+    Error,
+};
+
+#[derive(Clone)]
+pub(crate) enum OwnedInternal {
+    /// An extra large signed integer.
+    BigSigned(i128),
+    /// An extra large unsigned integer.
+    BigUnsigned(u128),
+    /// A floating point number.
+    Float(f64),
+    /// A boolean value.
+    Bool(bool),
+    /// A UTF8 codepoint.
+    Char(char),
+    /// A UTF8 string.
+    Str(Box<str>),
+    /// An empty value.
+    None,
+
+    /// A debuggable value.
+    Debug(internal::fmt::owned::OwnedFmt),
+    /// A displayable value.
+    Display(internal::fmt::owned::OwnedFmt),
+
+    #[cfg(feature = "error")]
+    Error(internal::error::OwnedError),
+}
+
+impl OwnedInternal {
+    pub(crate) fn by_ref<'v>(&'v self) -> Internal<'v> {
+        match self {
+            #[cfg(not(feature = "inline-i128"))]
+            OwnedInternal::BigSigned(v) => Internal::BigSigned(v),
+            #[cfg(feature = "inline-i128")]
+            OwnedInternal::BigSigned(v) => Internal::BigSigned(*v),
+            #[cfg(not(feature = "inline-i128"))]
+            OwnedInternal::BigUnsigned(v) => Internal::BigUnsigned(v),
+            #[cfg(feature = "inline-i128")]
+            OwnedInternal::BigUnsigned(v) => Internal::BigUnsigned(*v),
+            OwnedInternal::Float(v) => Internal::Float(*v),
+            OwnedInternal::Bool(v) => Internal::Bool(*v),
+            OwnedInternal::Char(v) => Internal::Char(*v),
+            OwnedInternal::Str(v) => Internal::Str(v),
+            OwnedInternal::None => Internal::None,
+
+            OwnedInternal::Debug(v) => Internal::Debug(v),
+            OwnedInternal::Display(v) => Internal::Display(v),
+
+            #[cfg(feature = "error")]
+            OwnedInternal::Error(v) => Internal::Error(v),
+        }
+    }
+}
+
+impl<'v> Internal<'v> {
+    pub(crate) fn to_owned(&self) -> OwnedInternal {
+        struct OwnedVisitor(OwnedInternal);
+
+        impl<'v> InternalVisitor<'v> for OwnedVisitor {
+            fn debug(&mut self, v: &dyn internal::fmt::Debug) -> Result<(), Error> {
+                self.0 = OwnedInternal::Debug(internal::fmt::owned::buffer_debug(v));
+                Ok(())
+            }
+
+            fn display(&mut self, v: &dyn internal::fmt::Display) -> Result<(), Error> {
+                self.0 = OwnedInternal::Display(internal::fmt::owned::buffer_display(v));
+                Ok(())
+            }
+
+            fn u64(&mut self, v: u64) -> Result<(), Error> {
+                self.0 = OwnedInternal::BigUnsigned(v as u128);
+                Ok(())
+            }
+
+            fn i64(&mut self, v: i64) -> Result<(), Error> {
+                self.0 = OwnedInternal::BigSigned(v as i128);
+                Ok(())
+            }
+
+            fn u128(&mut self, v: &u128) -> Result<(), Error> {
+                self.0 = OwnedInternal::BigUnsigned(*v);
+                Ok(())
+            }
+
+            fn i128(&mut self, v: &i128) -> Result<(), Error> {
+                self.0 = OwnedInternal::BigSigned(*v);
+                Ok(())
+            }
+
+            fn f64(&mut self, v: f64) -> Result<(), Error> {
+                self.0 = OwnedInternal::Float(v);
+                Ok(())
+            }
+
+            fn bool(&mut self, v: bool) -> Result<(), Error> {
+                self.0 = OwnedInternal::Bool(v);
+                Ok(())
+            }
+
+            fn char(&mut self, v: char) -> Result<(), Error> {
+                self.0 = OwnedInternal::Char(v);
+                Ok(())
+            }
+
+            fn str(&mut self, v: &str) -> Result<(), Error> {
+                self.0 = OwnedInternal::Str(v.into());
+                Ok(())
+            }
+
+            fn none(&mut self) -> Result<(), Error> {
+                self.0 = OwnedInternal::None;
+                Ok(())
+            }
+
+            #[cfg(feature = "error")]
+            fn error(&mut self, v: &(dyn internal::error::Error + 'static)) -> Result<(), Error> {
+                self.0 = OwnedInternal::Error(internal::error::buffer_error(v));
+                Ok(())
+            }
+
+            #[cfg(feature = "sval2")]
+            fn sval2(&mut self, v: &dyn internal::sval::v2::Value) -> Result<(), Error> {
+                todo!()
+            }
+
+            #[cfg(feature = "serde1")]
+            fn serde1(&mut self, v: &dyn internal::serde::v1::Serialize) -> Result<(), Error> {
+                todo!()
+            }
+        }
+
+        let mut visitor = OwnedVisitor(OwnedInternal::None);
+
+        let _ = self.internal_visit(&mut visitor);
+
+        visitor.0
+    }
+}

--- a/src/internal/serde/v1.rs
+++ b/src/internal/serde/v1.rs
@@ -6,7 +6,7 @@
 use crate::{
     fill::Slot,
     internal::{Internal, InternalVisitor},
-    std::{any::Any, fmt},
+    std::{any::Any, boxed::Box, fmt},
     Error, ValueBag,
 };
 
@@ -443,10 +443,10 @@ impl value_bag_serde1::lib::ser::Error for Unsupported {
 
 impl value_bag_serde1::lib::ser::StdError for Unsupported {}
 
-pub(crate) use value_bag_serde1::buf::Owned as OwnedSerialize;
+pub(crate) type OwnedSerialize = Box<value_bag_serde1::buf::Owned>;
 
 pub(crate) fn buffer(v: impl value_bag_serde1::lib::Serialize) -> OwnedSerialize {
-    OwnedSerialize::buffer(v).unwrap()
+    Box::new(value_bag_serde1::buf::Owned::buffer(v).unwrap())
 }
 
 #[cfg(test)]

--- a/src/internal/serde/v1.rs
+++ b/src/internal/serde/v1.rs
@@ -206,7 +206,7 @@ impl value_bag_serde1::lib::Serialize for crate::OwnedValueBag {
     where
         S: value_bag_serde1::lib::Serializer,
     {
-        value_bag_serde1::lib::Serialize::serialize(&self.to_value(), s)
+        value_bag_serde1::lib::Serialize::serialize(&self.by_ref(), s)
     }
 }
 
@@ -442,6 +442,12 @@ impl value_bag_serde1::lib::ser::Error for Unsupported {
 }
 
 impl value_bag_serde1::lib::ser::StdError for Unsupported {}
+
+pub(crate) use value_bag_serde1::buf::Owned as OwnedSerialize;
+
+pub(crate) fn buffer(v: impl value_bag_serde1::lib::Serialize) -> OwnedSerialize {
+    OwnedSerialize::buffer(v).unwrap()
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/internal/serde/v1.rs
+++ b/src/internal/serde/v1.rs
@@ -613,13 +613,6 @@ mod tests {
         value_bag_sval2::test::assert_tokens(&value, &[Token::U64(42)]);
     }
 
-    #[test]
-    #[cfg(feature = "owned")]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn serde1_to_owned() {
-        todo!()
-    }
-
     #[cfg(feature = "std")]
     mod std_support {
         use super::*;

--- a/src/internal/serde/v1.rs
+++ b/src/internal/serde/v1.rs
@@ -202,8 +202,8 @@ impl<'v> value_bag_serde1::lib::Serialize for ValueBag<'v> {
 
 #[cfg(feature = "alloc")]
 impl value_bag_serde1::lib::Serialize for crate::OwnedValueBag {
-     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-     where
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where
         S: value_bag_serde1::lib::Serializer,
     {
         value_bag_serde1::lib::Serialize::serialize(&self.to_value(), s)

--- a/src/internal/serde/v1.rs
+++ b/src/internal/serde/v1.rs
@@ -200,6 +200,16 @@ impl<'v> value_bag_serde1::lib::Serialize for ValueBag<'v> {
     }
 }
 
+#[cfg(feature = "alloc")]
+impl value_bag_serde1::lib::Serialize for crate::OwnedValueBag {
+     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+     where
+        S: value_bag_serde1::lib::Serializer,
+    {
+        value_bag_serde1::lib::Serialize::serialize(&self.to_value(), s)
+    }
+}
+
 pub use value_bag_serde1::erased::Serialize;
 
 pub(in crate::internal) fn fmt(f: &mut fmt::Formatter, v: &dyn Serialize) -> Result<(), Error> {

--- a/src/internal/sval/v2.rs
+++ b/src/internal/sval/v2.rs
@@ -81,16 +81,6 @@ impl<'v> value_bag_sval2::lib::Value for ValueBag<'v> {
     }
 }
 
-#[cfg(feature = "alloc")]
-impl value_bag_sval2::lib::Value for crate::OwnedValueBag {
-    fn stream<'sval, S: value_bag_sval2::lib::Stream<'sval> + ?Sized>(
-        &'sval self,
-        s: &mut S,
-    ) -> value_bag_sval2::lib::Result {
-        value_bag_sval2::lib_ref::ValueRef::stream_ref(&self.by_ref(), s)
-    }
-}
-
 impl<'sval> value_bag_sval2::lib_ref::ValueRef<'sval> for ValueBag<'sval> {
     fn stream_ref<S: value_bag_sval2::lib::Stream<'sval> + ?Sized>(
         &self,
@@ -312,9 +302,16 @@ impl Error {
     }
 }
 
-#[cfg(feature = "alloc")]
+#[cfg(feature = "owned")]
 pub(crate) mod owned {
-    use super::*;
+    impl value_bag_sval2::lib::Value for crate::OwnedValueBag {
+        fn stream<'sval, S: value_bag_sval2::lib::Stream<'sval> + ?Sized>(
+            &'sval self,
+            s: &mut S,
+        ) -> value_bag_sval2::lib::Result {
+            value_bag_sval2::lib_ref::ValueRef::stream_ref(&self.by_ref(), s)
+        }
+    }
 
     pub(crate) type OwnedValue = value_bag_sval2::buffer::Value<'static>;
 
@@ -506,6 +503,13 @@ mod tests {
         }
 
         assert_ser_tokens(&ValueBag::capture_sval2(&TestSval), &[Token::U64(42)]);
+    }
+
+    #[test]
+    #[cfg(feature = "owned")]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn sval2_to_owned() {
+        todo!()
     }
 
     #[cfg(feature = "std")]

--- a/src/internal/sval/v2.rs
+++ b/src/internal/sval/v2.rs
@@ -505,13 +505,6 @@ mod tests {
         assert_ser_tokens(&ValueBag::capture_sval2(&TestSval), &[Token::U64(42)]);
     }
 
-    #[test]
-    #[cfg(feature = "owned")]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn sval2_to_owned() {
-        todo!()
-    }
-
     #[cfg(feature = "std")]
     mod std_support {
         use super::*;

--- a/src/internal/sval/v2.rs
+++ b/src/internal/sval/v2.rs
@@ -81,6 +81,13 @@ impl<'v> value_bag_sval2::lib::Value for ValueBag<'v> {
     }
 }
 
+#[cfg(feature = "alloc")]
+impl value_bag_sval2::lib::Value for crate::OwnedValueBag {
+    fn stream<'sval, S: value_bag_sval2::lib::Stream<'sval> + ?Sized>(&'sval self, s: &mut S) -> value_bag_sval2::lib::Result {
+        value_bag_sval2::lib_ref::ValueRef::stream_ref(&self.to_value(), s)
+    }
+}
+
 impl<'sval> value_bag_sval2::lib_ref::ValueRef<'sval> for ValueBag<'sval> {
     fn stream_ref<S: value_bag_sval2::lib::Stream<'sval> + ?Sized>(
         &self,

--- a/src/internal/sval/v2.rs
+++ b/src/internal/sval/v2.rs
@@ -83,7 +83,10 @@ impl<'v> value_bag_sval2::lib::Value for ValueBag<'v> {
 
 #[cfg(feature = "alloc")]
 impl value_bag_sval2::lib::Value for crate::OwnedValueBag {
-    fn stream<'sval, S: value_bag_sval2::lib::Stream<'sval> + ?Sized>(&'sval self, s: &mut S) -> value_bag_sval2::lib::Result {
+    fn stream<'sval, S: value_bag_sval2::lib::Stream<'sval> + ?Sized>(
+        &'sval self,
+        s: &mut S,
+    ) -> value_bag_sval2::lib::Result {
         value_bag_sval2::lib_ref::ValueRef::stream_ref(&self.to_value(), s)
     }
 }

--- a/src/internal/sval/v2.rs
+++ b/src/internal/sval/v2.rs
@@ -87,7 +87,7 @@ impl value_bag_sval2::lib::Value for crate::OwnedValueBag {
         &'sval self,
         s: &mut S,
     ) -> value_bag_sval2::lib::Result {
-        value_bag_sval2::lib_ref::ValueRef::stream_ref(&self.to_value(), s)
+        value_bag_sval2::lib_ref::ValueRef::stream_ref(&self.by_ref(), s)
     }
 }
 
@@ -309,6 +309,17 @@ impl Error {
 
     pub(in crate::internal) fn into_sval2(self) -> value_bag_sval2::lib::Error {
         value_bag_sval2::lib::Error::new()
+    }
+}
+
+#[cfg(feature = "alloc")]
+pub(crate) mod owned {
+    use super::*;
+
+    pub(crate) type OwnedValue = value_bag_sval2::buffer::Value<'static>;
+
+    pub(crate) fn buffer(v: impl value_bag_sval2::lib::Value) -> OwnedValue {
+        OwnedValue::collect_owned(v).unwrap()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,9 +111,9 @@ pub mod visit;
 #[cfg(any(test, feature = "test"))]
 pub mod test;
 
-#[cfg(feature = "alloc")]
+#[cfg(feature = "owned")]
 mod owned;
-#[cfg(feature = "alloc")]
+#[cfg(feature = "owned")]
 pub use self::owned::*;
 
 pub use self::error::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,17 +80,21 @@ underlying value, bridging it if it was produced for a different framework.
 extern crate std;
 
 #[cfg(all(not(test), feature = "alloc", not(feature = "std")))]
+#[macro_use]
+#[allow(unused_imports)]
 extern crate core;
 
 #[cfg(all(not(test), feature = "alloc", not(feature = "std")))]
+#[macro_use]
+#[allow(unused_imports)]
 extern crate alloc;
 
 #[cfg(all(not(test), feature = "alloc", not(feature = "std")))]
 mod std {
-   pub use crate::{
-      alloc::{boxed},
-      core::*,
-   };
+    pub use crate::{
+        alloc::{boxed, string},
+        core::*,
+    };
 }
 
 #[cfg(not(any(feature = "alloc", feature = "std", test)))]
@@ -415,10 +419,8 @@ mod tests {
 
         if size > limit {
             panic!(
-                "`ValueBag` size ({} bytes) is too large (expected up to {} bytes)\n`(`&dyn` + `TypeId`): {} bytes",
-                size,
-                limit,
-                mem::size_of::<(&dyn internal::fmt::Debug, crate::std::any::TypeId)>(),
+                "`ValueBag` size ({} bytes) is too large (expected up to {} bytes)",
+                size, limit,
             );
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,21 @@ underlying value, bridging it if it was produced for a different framework.
 #[allow(unused_imports)]
 extern crate std;
 
-#[cfg(not(any(feature = "std", test)))]
+#[cfg(all(not(test), feature = "alloc", not(feature = "std")))]
+extern crate core;
+
+#[cfg(all(not(test), feature = "alloc", not(feature = "std")))]
+extern crate alloc;
+
+#[cfg(all(not(test), feature = "alloc", not(feature = "std")))]
+mod std {
+   pub use crate::{
+      alloc::{boxed},
+      core::*,
+   };
+}
+
+#[cfg(not(any(feature = "alloc", feature = "std", test)))]
 #[macro_use]
 #[allow(unused_imports)]
 extern crate core as std;
@@ -92,6 +106,11 @@ pub mod visit;
 
 #[cfg(any(test, feature = "test"))]
 pub mod test;
+
+#[cfg(feature = "alloc")]
+mod owned;
+#[cfg(feature = "alloc")]
+pub use self::owned::*;
 
 pub use self::error::Error;
 

--- a/src/owned.rs
+++ b/src/owned.rs
@@ -40,6 +40,9 @@ impl OwnedValueBag {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
+    
     use super::*;
 
     use crate::{fill, std::{mem, string::ToString, io}};

--- a/src/owned.rs
+++ b/src/owned.rs
@@ -1,0 +1,29 @@
+use crate::{ValueBag, internal};
+
+pub struct OwnedValueBag {
+    inner: internal::OwnedInternal,
+}
+
+impl<'v> ValueBag<'v> {
+    pub fn to_owned(&self) -> OwnedValueBag {
+        todo!()
+    }
+}
+
+impl OwnedValueBag {
+    pub fn to_value<'v>(&'v self) -> ValueBag<'v> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn is_send_sync() {
+        fn assert<T: Send + Sync + 'static>() {}
+        
+        assert::<OwnedValueBag>();
+    }
+}

--- a/src/owned.rs
+++ b/src/owned.rs
@@ -1,11 +1,20 @@
 use crate::{internal, ValueBag};
 
+/// A dynamic structured value.
+///
+/// This type is an owned variant of [`ValueBag`] that can be
+/// constructed using its [`to_owned`](struct.ValueBag.html#method.to_owned) method.
+/// `OwnedValueBag`s are suitable for storing and sharing across threads.
+///
+/// `OwnedValueBag`s can be inspected by converting back into a regular `ValueBag`
+/// using the [`by_ref`](#method.by_ref) method.
 #[derive(Clone)]
 pub struct OwnedValueBag {
     inner: internal::owned::OwnedInternal,
 }
 
 impl<'v> ValueBag<'v> {
+    /// Buffer this value into an [`OwnedValueBag`].
     pub fn to_owned(&self) -> OwnedValueBag {
         OwnedValueBag {
             inner: self.inner.to_owned(),
@@ -14,6 +23,14 @@ impl<'v> ValueBag<'v> {
 }
 
 impl OwnedValueBag {
+    /// Get a regular [`ValueBag`] from this type.
+    ///
+    /// Once a `ValueBag` has been buffered, it will behave
+    /// slightly differently when converted back:
+    ///
+    /// - `fmt::Debug` won't use formatting flags.
+    /// - `serde::Serialize` will use the text-based representation.
+    /// - The original type will change, so downcasting won't work.
     pub fn by_ref<'v>(&'v self) -> ValueBag<'v> {
         ValueBag {
             inner: self.inner.by_ref(),

--- a/src/owned.rs
+++ b/src/owned.rs
@@ -94,6 +94,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "error")]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn error_to_owned() {
         let value = ValueBag::from_dyn_error(&io::Error::new(io::ErrorKind::Other, "something failed!")).to_owned();

--- a/src/owned.rs
+++ b/src/owned.rs
@@ -1,29 +1,51 @@
-use crate::{ValueBag, internal};
+use crate::{internal, ValueBag};
 
+#[derive(Clone)]
 pub struct OwnedValueBag {
-    inner: internal::OwnedInternal,
+    inner: internal::owned::OwnedInternal,
 }
 
 impl<'v> ValueBag<'v> {
     pub fn to_owned(&self) -> OwnedValueBag {
-        todo!()
+        OwnedValueBag {
+            inner: self.inner.to_owned(),
+        }
     }
 }
 
 impl OwnedValueBag {
-    pub fn to_value<'v>(&'v self) -> ValueBag<'v> {
-        todo!()
+    pub fn by_ref<'v>(&'v self) -> ValueBag<'v> {
+        ValueBag {
+            inner: self.inner.by_ref(),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
+    use crate::std::mem;
+
+    const SIZE_LIMIT_U64: usize = 4;
+
     #[test]
     fn is_send_sync() {
         fn assert<T: Send + Sync + 'static>() {}
-        
+
         assert::<OwnedValueBag>();
+    }
+
+    #[test]
+    fn owned_value_bag_size() {
+        let size = mem::size_of::<OwnedValueBag>();
+        let limit = mem::size_of::<u64>() * SIZE_LIMIT_U64;
+
+        if size > limit {
+            panic!(
+                "`OwnedValueBag` size ({} bytes) is too large (expected up to {} bytes)",
+                size, limit,
+            );
+        }
     }
 }

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -75,100 +75,68 @@ pub trait Visit<'v> {
 
     /// Visit an unsigned integer.
     #[inline]
-    #[cfg(not(test))]
     fn visit_u64(&mut self, value: u64) -> Result<(), Error> {
         self.visit_any(value.into())
     }
-    #[cfg(test)]
-    fn visit_u64(&mut self, value: u64) -> Result<(), Error>;
 
     /// Visit a signed integer.
     #[inline]
-    #[cfg(not(test))]
     fn visit_i64(&mut self, value: i64) -> Result<(), Error> {
         self.visit_any(value.into())
     }
-    #[cfg(test)]
-    fn visit_i64(&mut self, value: i64) -> Result<(), Error>;
 
     /// Visit a big unsigned integer.
     #[inline]
-    #[cfg(not(test))]
     fn visit_u128(&mut self, value: u128) -> Result<(), Error> {
         self.visit_any((&value).into())
     }
-    #[cfg(test)]
-    fn visit_u128(&mut self, value: u128) -> Result<(), Error>;
 
     /// Visit a big signed integer.
     #[inline]
-    #[cfg(not(test))]
     fn visit_i128(&mut self, value: i128) -> Result<(), Error> {
         self.visit_any((&value).into())
     }
-    #[cfg(test)]
-    fn visit_i128(&mut self, value: i128) -> Result<(), Error>;
 
     /// Visit a floating point.
     #[inline]
-    #[cfg(not(test))]
     fn visit_f64(&mut self, value: f64) -> Result<(), Error> {
         self.visit_any(value.into())
     }
-    #[cfg(test)]
-    fn visit_f64(&mut self, value: f64) -> Result<(), Error>;
 
     /// Visit a boolean.
     #[inline]
-    #[cfg(not(test))]
     fn visit_bool(&mut self, value: bool) -> Result<(), Error> {
         self.visit_any(value.into())
     }
-    #[cfg(test)]
-    fn visit_bool(&mut self, value: bool) -> Result<(), Error>;
 
     /// Visit a string.
     #[inline]
-    #[cfg(not(test))]
     fn visit_str(&mut self, value: &str) -> Result<(), Error> {
         self.visit_any(value.into())
     }
-    #[cfg(test)]
-    fn visit_str(&mut self, value: &str) -> Result<(), Error>;
 
     /// Visit a string.
     #[inline]
-    #[cfg(not(test))]
     fn visit_borrowed_str(&mut self, value: &'v str) -> Result<(), Error> {
         self.visit_str(value)
     }
-    #[cfg(test)]
-    fn visit_borrowed_str(&mut self, value: &'v str) -> Result<(), Error>;
 
     /// Visit a Unicode character.
     #[inline]
-    #[cfg(not(test))]
     fn visit_char(&mut self, value: char) -> Result<(), Error> {
         let mut b = [0; 4];
         self.visit_str(&*value.encode_utf8(&mut b))
     }
-    #[cfg(test)]
-    fn visit_char(&mut self, value: char) -> Result<(), Error>;
 
     /// Visit an error.
     #[inline]
-    #[cfg(not(test))]
     #[cfg(feature = "error")]
     fn visit_error(&mut self, err: &(dyn crate::std::error::Error + 'static)) -> Result<(), Error> {
         self.visit_any(ValueBag::from_dyn_error(err))
     }
-    #[cfg(test)]
-    #[cfg(feature = "error")]
-    fn visit_error(&mut self, err: &(dyn crate::std::error::Error + 'static)) -> Result<(), Error>;
 
     /// Visit an error.
     #[inline]
-    #[cfg(not(test))]
     #[cfg(feature = "error")]
     fn visit_borrowed_error(
         &mut self,
@@ -176,12 +144,6 @@ pub trait Visit<'v> {
     ) -> Result<(), Error> {
         self.visit_any(ValueBag::from_dyn_error(err))
     }
-    #[cfg(test)]
-    #[cfg(feature = "error")]
-    fn visit_borrowed_error(
-        &mut self,
-        err: &'v (dyn crate::std::error::Error + 'static),
-    ) -> Result<(), Error>;
 }
 
 impl<'a, 'v, T: ?Sized> Visit<'v> for &'a mut T


### PR DESCRIPTION
Closes #50 

This PR starts to spike out a `Send + Sync + 'static` owned value. For a start, we'll just unconditionally allocate `serde_buf` and `sval_buffer` into a `Box` to keep the size of the type down, but can freely optimize this internally.