### PR TITLE
Add conversion between &OwnedValueBag and ValueBag

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -91,6 +91,20 @@ mod std_support {
     }
 }
 
+#[cfg(feature = "owned")]
+mod owned_support {
+    use super::*;
+
+    use crate::OwnedValueBag;
+
+    impl<'v> From<&'v OwnedValueBag> for ValueBag<'v> {
+        #[inline]
+        fn from(v: &'v OwnedValueBag) -> ValueBag<'v> {
+            v.by_ref()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(target_arch = "wasm32")]

--- a/src/owned.rs
+++ b/src/owned.rs
@@ -45,7 +45,7 @@ mod tests {
     
     use super::*;
 
-    use crate::{fill, std::{mem, string::ToString, io}};
+    use crate::{fill, std::{mem, string::ToString}};
 
     const SIZE_LIMIT_U64: usize = 4;
 
@@ -100,6 +100,8 @@ mod tests {
     #[cfg(feature = "error")]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn error_to_owned() {
+        use crate::std::io;
+
         let value = ValueBag::from_dyn_error(&io::Error::new(io::ErrorKind::Other, "something failed!")).to_owned();
 
         assert!(matches!(value.inner, internal::owned::OwnedInternal::Error(_)));


### PR DESCRIPTION
This ensures `&OwnedValueBag` can be used in place of an `Into<ValueBag>` bound, which is a generic way to describe types that can be captured.