### PR TITLE
Add license files to all published crates

### DIFF
--- a/meta/serde1/LICENSE-APACHE
+++ b/meta/serde1/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/meta/serde1/LICENSE-MIT
+++ b/meta/serde1/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/meta/sval2/LICENSE-APACHE
+++ b/meta/sval2/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/meta/sval2/LICENSE-MIT
+++ b/meta/sval2/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT


### PR DESCRIPTION
It looks like it was missed to add license files into the new value-bag-serde1 and value-bag-sval2 crates. This PR should make sure license files are included in all published crates (which is one of the conditions of both the Apache-2.0 and MIT licenses).