### PR TITLE
Avoid panicking when buffering values

### DIFF
--- a/src/internal/cast/mod.rs
+++ b/src/internal/cast/mod.rs
@@ -221,6 +221,11 @@ impl<'v> Internal<'v> {
             fn serde1(&mut self, v: &dyn super::serde::v1::Serialize) -> Result<(), Error> {
                 super::serde::v1::internal_visit(v, self)
             }
+
+            fn poisoned(&mut self, _: &'static str) -> Result<(), Error> {
+                self.0 = Cast::None;
+                Ok(())
+            }
         }
 
         match &self {

--- a/src/internal/fmt.rs
+++ b/src/internal/fmt.rs
@@ -217,6 +217,12 @@ impl<'v> Debug for ValueBag<'v> {
             ) -> Result<(), Error> {
                 crate::internal::serde::v1::fmt(self.0, v)
             }
+
+            fn poisoned(&mut self, msg: &'static str) -> Result<(), Error> {
+                write!(self.0, "<{msg}>")?;
+
+                Ok(())
+            }
         }
 
         self.internal_visit(&mut DebugVisitor(f))
@@ -313,6 +319,12 @@ impl<'v> Display for ValueBag<'v> {
                 v: &dyn crate::internal::serde::v1::Serialize,
             ) -> Result<(), Error> {
                 crate::internal::serde::v1::fmt(self.0, v)
+            }
+
+            fn poisoned(&mut self, msg: &'static str) -> Result<(), Error> {
+                write!(self.0, "<{msg}>")?;
+
+                Ok(())
             }
         }
 

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -87,6 +87,7 @@ pub(crate) enum Internal<'v> {
     Serde1(&'v dyn serde::v1::DowncastSerialize),
 
     /// A poisoned value.
+    #[cfg_attr(not(feature = "owned"), allow(dead_code))]
     Poisoned(&'static str),
 }
 

--- a/src/owned.rs
+++ b/src/owned.rs
@@ -42,10 +42,13 @@ impl OwnedValueBag {
 mod tests {
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::*;
-    
+
     use super::*;
 
-    use crate::{fill, std::{mem, string::ToString}};
+    use crate::{
+        fill,
+        std::{mem, string::ToString},
+    };
 
     const SIZE_LIMIT_U64: usize = 4;
 
@@ -74,7 +77,10 @@ mod tests {
     fn fill_to_owned() {
         let value = ValueBag::from_fill(&|slot: fill::Slot| slot.fill_any(42u64)).to_owned();
 
-        assert!(matches!(value.inner, internal::owned::OwnedInternal::BigUnsigned(42)));
+        assert!(matches!(
+            value.inner,
+            internal::owned::OwnedInternal::BigUnsigned(42)
+        ));
     }
 
     #[test]
@@ -83,8 +89,14 @@ mod tests {
         let debug = ValueBag::from_debug(&"a value").to_owned();
         let display = ValueBag::from_display(&"a value").to_owned();
 
-        assert!(matches!(debug.inner, internal::owned::OwnedInternal::Debug(_)));
-        assert!(matches!(display.inner, internal::owned::OwnedInternal::Display(_)));
+        assert!(matches!(
+            debug.inner,
+            internal::owned::OwnedInternal::Debug(_)
+        ));
+        assert!(matches!(
+            display.inner,
+            internal::owned::OwnedInternal::Display(_)
+        ));
 
         assert_eq!("\"a value\"", debug.to_string());
         assert_eq!("a value", display.to_string());
@@ -102,9 +114,14 @@ mod tests {
     fn error_to_owned() {
         use crate::std::io;
 
-        let value = ValueBag::from_dyn_error(&io::Error::new(io::ErrorKind::Other, "something failed!")).to_owned();
+        let value =
+            ValueBag::from_dyn_error(&io::Error::new(io::ErrorKind::Other, "something failed!"))
+                .to_owned();
 
-        assert!(matches!(value.inner, internal::owned::OwnedInternal::Error(_)));
+        assert!(matches!(
+            value.inner,
+            internal::owned::OwnedInternal::Error(_)
+        ));
 
         let value = value.by_ref();
 
@@ -119,7 +136,10 @@ mod tests {
     fn serde1_to_owned() {
         let value = ValueBag::from_serde1(&42u64).to_owned();
 
-        assert!(matches!(value.inner, internal::owned::OwnedInternal::Serde1(_)));
+        assert!(matches!(
+            value.inner,
+            internal::owned::OwnedInternal::Serde1(_)
+        ));
 
         let value = value.by_ref();
 
@@ -132,7 +152,10 @@ mod tests {
     fn sval2_to_owned() {
         let value = ValueBag::from_sval2(&42u64).to_owned();
 
-        assert!(matches!(value.inner, internal::owned::OwnedInternal::Sval2(_)));
+        assert!(matches!(
+            value.inner,
+            internal::owned::OwnedInternal::Sval2(_)
+        ));
 
         let value = value.by_ref();
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -48,6 +48,8 @@ pub enum TestToken {
     Serde {
         version: u32,
     },
+
+    Poisoned(String),
 }
 
 impl<'v> ValueBag<'v> {
@@ -130,6 +132,11 @@ impl<'v> ValueBag<'v> {
             #[cfg(feature = "serde1")]
             fn serde1(&mut self, _: &dyn internal::serde::v1::Serialize) -> Result<(), Error> {
                 self.0 = Some(TestToken::Serde { version: 1 });
+                Ok(())
+            }
+
+            fn poisoned(&mut self, msg: &'static str) -> Result<(), Error> {
+                self.0 = Some(TestToken::Poisoned(msg.into()));
                 Ok(())
             }
         }

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -307,6 +307,10 @@ impl<'v> ValueBag<'v> {
             fn serde1(&mut self, v: &dyn internal::serde::v1::Serialize) -> Result<(), Error> {
                 internal::serde::v1::internal_visit(v, self)
             }
+
+            fn poisoned(&mut self, msg: &'static str) -> Result<(), Error> {
+                Err(Error::msg(msg))
+            }
         }
 
         self.internal_visit(&mut Visitor(visitor))


### PR DESCRIPTION
Closes #63 

This will need a fix in `sval_buffer` too, which looks like it panics if the `Value` fails to buffer too.