### PR TITLE
Add as_f64 and as_f64_seq

### DIFF
--- a/src/internal/serde/v1.rs
+++ b/src/internal/serde/v1.rs
@@ -871,6 +871,18 @@ mod tests {
                 .expect("invalid value")
             );
         }
+
+        #[test]
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+        fn serde1_as_seq() {
+            assert_eq!(
+                vec![1.0, 2.0, 3.0],
+                ValueBag::capture_serde1(&[
+                    1.0, 2.0, 3.0,
+                ])
+                .as_f64_seq::<Vec<f64>>()
+            );
+        }
     }
 
     #[cfg(feature = "std")]

--- a/src/internal/sval/v2.rs
+++ b/src/internal/sval/v2.rs
@@ -732,6 +732,18 @@ mod tests {
                 .expect("invalid value")
             );
         }
+
+        #[test]
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+        fn sval2_as_seq() {
+            assert_eq!(
+                vec![1.0, 2.0, 3.0],
+                ValueBag::capture_sval2(&[
+                    1.0, 2.0, 3.0,
+                ])
+                .as_f64_seq::<Vec<f64>>()
+            );
+        }
     }
 
     #[cfg(feature = "std")]

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -60,6 +60,31 @@ impl<'v> ValueBag<'v> {
         self.inner.seq::<ExtendPrimitive<S, f64>>().map(|seq| seq.0)
     }
 
+    /// Get a collection `S` of `f64`s from this value.
+    /// 
+    /// If this value is a sequence then the collection `S` will be extended
+    /// with the conversion of each of its elements. The conversion is the
+    /// same as [`ValueBag::as_f64`].
+    /// 
+    /// If this value is not a sequence then this method will return an
+    /// empty collection.
+    /// 
+    /// This is similar to [`ValueBag::to_f64_seq`], but can be more
+    /// convenient when there's no need to distinguish between an empty
+    /// collection and a non-collection, or between `f64` and non-`f64` elements.
+    pub fn as_f64_seq<S: Default + Extend<f64>>(&self) -> S {
+        #[derive(Default)]
+        struct ExtendF64<S>(S);
+
+        impl<'a, S: Extend<f64>> ExtendValue<'a> for ExtendF64<S> {
+            fn extend<'b>(&mut self, inner: Internal<'b>) {
+                self.0.extend(Some(ValueBag { inner }.as_f64()))
+            }
+        }
+
+        self.inner.seq::<ExtendF64<S>>().map(|seq| seq.0).unwrap_or_default()
+    }
+
     /// Try get a collection `S` of `bool`s from this value.
     ///
     /// If this value is a sequence then the collection `S` will be extended


### PR DESCRIPTION
Floating points are interesting data types because they can internally encode whether or not a value is actually a number or not through NaNs.

There are also cases where you want some numeric representation of a value without being too concerned with potential rounding to get there. In those cases, having a quick `as`-like conversion to get a floating point from any kind of numeric input saves needing to write your own visitor.