### PR TITLE
Add const ctors for ValueBag

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,24 +1,18 @@
 //! Converting standard types into `ValueBag`s.
 
-use crate::internal::Internal;
-
 use super::{Error, ValueBag};
 
 impl<'v> From<()> for ValueBag<'v> {
     #[inline]
     fn from(_: ()) -> Self {
-        ValueBag {
-            inner: Internal::None,
-        }
+        ValueBag::empty()
     }
 }
 
 impl<'v> From<u8> for ValueBag<'v> {
     #[inline]
     fn from(v: u8) -> Self {
-        ValueBag {
-            inner: Internal::Unsigned(v as u64),
-        }
+        ValueBag::from_u8(v)
     }
 }
 
@@ -37,9 +31,7 @@ impl<'v> TryFrom<ValueBag<'v>> for u8 {
 impl<'v> From<u16> for ValueBag<'v> {
     #[inline]
     fn from(v: u16) -> Self {
-        ValueBag {
-            inner: Internal::Unsigned(v as u64),
-        }
+        ValueBag::from_u16(v)
     }
 }
 
@@ -58,9 +50,7 @@ impl<'v> TryFrom<ValueBag<'v>> for u16 {
 impl<'v> From<u32> for ValueBag<'v> {
     #[inline]
     fn from(v: u32) -> Self {
-        ValueBag {
-            inner: Internal::Unsigned(v as u64),
-        }
+        ValueBag::from_u32(v)
     }
 }
 
@@ -79,9 +69,7 @@ impl<'v> TryFrom<ValueBag<'v>> for u32 {
 impl<'v> From<u64> for ValueBag<'v> {
     #[inline]
     fn from(v: u64) -> Self {
-        ValueBag {
-            inner: Internal::Unsigned(v),
-        }
+        ValueBag::from_u64(v)
     }
 }
 
@@ -97,9 +85,7 @@ impl<'v> TryFrom<ValueBag<'v>> for u64 {
 impl<'v> From<usize> for ValueBag<'v> {
     #[inline]
     fn from(v: usize) -> Self {
-        ValueBag {
-            inner: Internal::Unsigned(v as u64),
-        }
+        ValueBag::from_usize(v)
     }
 }
 
@@ -118,9 +104,7 @@ impl<'v> TryFrom<ValueBag<'v>> for usize {
 impl<'v> From<i8> for ValueBag<'v> {
     #[inline]
     fn from(v: i8) -> Self {
-        ValueBag {
-            inner: Internal::Signed(v as i64),
-        }
+        ValueBag::from_i8(v)
     }
 }
 
@@ -139,9 +123,7 @@ impl<'v> TryFrom<ValueBag<'v>> for i8 {
 impl<'v> From<i16> for ValueBag<'v> {
     #[inline]
     fn from(v: i16) -> Self {
-        ValueBag {
-            inner: Internal::Signed(v as i64),
-        }
+        ValueBag::from_i16(v)
     }
 }
 
@@ -160,9 +142,7 @@ impl<'v> TryFrom<ValueBag<'v>> for i16 {
 impl<'v> From<i32> for ValueBag<'v> {
     #[inline]
     fn from(v: i32) -> Self {
-        ValueBag {
-            inner: Internal::Signed(v as i64),
-        }
+        ValueBag::from_i32(v)
     }
 }
 
@@ -181,9 +161,7 @@ impl<'v> TryFrom<ValueBag<'v>> for i32 {
 impl<'v> From<i64> for ValueBag<'v> {
     #[inline]
     fn from(v: i64) -> Self {
-        ValueBag {
-            inner: Internal::Signed(v),
-        }
+        ValueBag::from_i64(v)
     }
 }
 
@@ -199,9 +177,7 @@ impl<'v> TryFrom<ValueBag<'v>> for i64 {
 impl<'v> From<isize> for ValueBag<'v> {
     #[inline]
     fn from(v: isize) -> Self {
-        ValueBag {
-            inner: Internal::Signed(v as i64),
-        }
+        ValueBag::from_isize(v)
     }
 }
 
@@ -220,18 +196,14 @@ impl<'v> TryFrom<ValueBag<'v>> for isize {
 impl<'v> From<f32> for ValueBag<'v> {
     #[inline]
     fn from(v: f32) -> Self {
-        ValueBag {
-            inner: Internal::Float(v as f64),
-        }
+        ValueBag::from_f32(v)
     }
 }
 
 impl<'v> From<f64> for ValueBag<'v> {
     #[inline]
     fn from(v: f64) -> Self {
-        ValueBag {
-            inner: Internal::Float(v),
-        }
+        ValueBag::from_f64(v)
     }
 }
 
@@ -250,9 +222,7 @@ impl<'v> TryFrom<ValueBag<'v>> for f64 {
 impl<'v> From<bool> for ValueBag<'v> {
     #[inline]
     fn from(v: bool) -> Self {
-        ValueBag {
-            inner: Internal::Bool(v),
-        }
+        ValueBag::from_bool(v)
     }
 }
 
@@ -268,9 +238,7 @@ impl<'v> TryFrom<ValueBag<'v>> for bool {
 impl<'v> From<char> for ValueBag<'v> {
     #[inline]
     fn from(v: char) -> Self {
-        ValueBag {
-            inner: Internal::Char(v),
-        }
+        ValueBag::from_char(v)
     }
 }
 
@@ -286,9 +254,7 @@ impl<'v> TryFrom<ValueBag<'v>> for char {
 impl<'v> From<&'v str> for ValueBag<'v> {
     #[inline]
     fn from(v: &'v str) -> Self {
-        ValueBag {
-            inner: Internal::Str(v),
-        }
+        ValueBag::from_str(v)
     }
 }
 
@@ -305,63 +271,42 @@ impl<'v> TryFrom<ValueBag<'v>> for &'v str {
 impl<'v> From<&'v ()> for ValueBag<'v> {
     #[inline]
     fn from(_: &'v ()) -> Self {
-        ValueBag {
-            inner: Internal::None,
-        }
+        ValueBag::empty()
     }
 }
 
 impl<'v> From<&'v u8> for ValueBag<'v> {
     #[inline]
     fn from(v: &'v u8) -> Self {
-        ValueBag {
-            inner: Internal::Unsigned(*v as u64),
-        }
+        ValueBag::from_u8(*v)
     }
 }
 
 impl<'v> From<&'v u16> for ValueBag<'v> {
     #[inline]
     fn from(v: &'v u16) -> Self {
-        ValueBag {
-            inner: Internal::Unsigned(*v as u64),
-        }
+        ValueBag::from_u16(*v)
     }
 }
 
 impl<'v> From<&'v u32> for ValueBag<'v> {
     #[inline]
     fn from(v: &'v u32) -> Self {
-        ValueBag {
-            inner: Internal::Unsigned(*v as u64),
-        }
+        ValueBag::from_u32(*v)
     }
 }
 
 impl<'v> From<&'v u64> for ValueBag<'v> {
     #[inline]
     fn from(v: &'v u64) -> Self {
-        ValueBag {
-            inner: Internal::Unsigned(*v),
-        }
+        ValueBag::from_u64(*v)
     }
 }
 
 impl<'v> From<&'v u128> for ValueBag<'v> {
     #[inline]
     fn from(v: &'v u128) -> Self {
-        #[cfg(feature = "inline-i128")]
-        {
-            ValueBag {
-                inner: Internal::BigUnsigned(*v),
-            }
-        }
-        #[cfg(not(feature = "inline-i128"))]
-        {
-            ValueBag {
-                inner: Internal::BigUnsigned(v),
-            }
-        }
+        ValueBag::from_u128_ref(v)
     }
 }
 
@@ -369,9 +314,7 @@ impl<'v> From<&'v u128> for ValueBag<'v> {
 impl<'v> From<u128> for ValueBag<'v> {
     #[inline]
     fn from(v: u128) -> Self {
-        ValueBag {
-            inner: Internal::BigUnsigned(v),
-        }
+        ValueBag::from_u128(v)
     }
 }
 
@@ -387,63 +330,42 @@ impl<'v> TryFrom<ValueBag<'v>> for u128 {
 impl<'v> From<&'v usize> for ValueBag<'v> {
     #[inline]
     fn from(v: &'v usize) -> Self {
-        ValueBag {
-            inner: Internal::Unsigned(*v as u64),
-        }
+        ValueBag::from_usize(*v)
     }
 }
 
 impl<'v> From<&'v i8> for ValueBag<'v> {
     #[inline]
     fn from(v: &'v i8) -> Self {
-        ValueBag {
-            inner: Internal::Signed(*v as i64),
-        }
+        ValueBag::from_i8(*v)
     }
 }
 
 impl<'v> From<&'v i16> for ValueBag<'v> {
     #[inline]
     fn from(v: &'v i16) -> Self {
-        ValueBag {
-            inner: Internal::Signed(*v as i64),
-        }
+        ValueBag::from_i16(*v)
     }
 }
 
 impl<'v> From<&'v i32> for ValueBag<'v> {
     #[inline]
     fn from(v: &'v i32) -> Self {
-        ValueBag {
-            inner: Internal::Signed(*v as i64),
-        }
+        ValueBag::from_i32(*v)
     }
 }
 
 impl<'v> From<&'v i64> for ValueBag<'v> {
     #[inline]
     fn from(v: &'v i64) -> Self {
-        ValueBag {
-            inner: Internal::Signed(*v),
-        }
+        ValueBag::from_i64(*v)
     }
 }
 
 impl<'v> From<&'v i128> for ValueBag<'v> {
     #[inline]
     fn from(v: &'v i128) -> Self {
-        #[cfg(feature = "inline-i128")]
-        {
-            ValueBag {
-                inner: Internal::BigSigned(*v),
-            }
-        }
-        #[cfg(not(feature = "inline-i128"))]
-        {
-            ValueBag {
-                inner: Internal::BigSigned(v),
-            }
-        }
+        ValueBag::from_i128_ref(v)
     }
 }
 
@@ -451,9 +373,7 @@ impl<'v> From<&'v i128> for ValueBag<'v> {
 impl<'v> From<i128> for ValueBag<'v> {
     #[inline]
     fn from(v: i128) -> Self {
-        ValueBag {
-            inner: Internal::BigSigned(v),
-        }
+        ValueBag::from_i128(v)
     }
 }
 
@@ -469,45 +389,35 @@ impl<'v> TryFrom<ValueBag<'v>> for i128 {
 impl<'v> From<&'v isize> for ValueBag<'v> {
     #[inline]
     fn from(v: &'v isize) -> Self {
-        ValueBag {
-            inner: Internal::Signed(*v as i64),
-        }
+        ValueBag::from_isize(*v)
     }
 }
 
 impl<'v> From<&'v f32> for ValueBag<'v> {
     #[inline]
     fn from(v: &'v f32) -> Self {
-        ValueBag {
-            inner: Internal::Float(*v as f64),
-        }
+        ValueBag::from_f32(*v)
     }
 }
 
 impl<'v> From<&'v f64> for ValueBag<'v> {
     #[inline]
     fn from(v: &'v f64) -> Self {
-        ValueBag {
-            inner: Internal::Float(*v),
-        }
+        ValueBag::from_f64(*v)
     }
 }
 
 impl<'v> From<&'v bool> for ValueBag<'v> {
     #[inline]
     fn from(v: &'v bool) -> Self {
-        ValueBag {
-            inner: Internal::Bool(*v),
-        }
+        ValueBag::from_bool(*v)
     }
 }
 
 impl<'v> From<&'v char> for ValueBag<'v> {
     #[inline]
     fn from(v: &'v char) -> Self {
-        ValueBag {
-            inner: Internal::Char(*v),
-        }
+        ValueBag::from_char(*v)
     }
 }
 
@@ -517,9 +427,7 @@ where
 {
     #[inline]
     fn from(v: &'v &'u str) -> Self {
-        ValueBag {
-            inner: Internal::Str(*v),
-        }
+        ValueBag::from_str(*v)
     }
 }
 
@@ -532,9 +440,7 @@ mod alloc_support {
     impl<'v> From<&'v String> for ValueBag<'v> {
         #[inline]
         fn from(v: &'v String) -> Self {
-            ValueBag {
-                inner: Internal::Str(&**v),
-            }
+            ValueBag::from_str(v)
         }
     }
 

--- a/src/internal/error.rs
+++ b/src/internal/error.rs
@@ -19,7 +19,7 @@ impl<'v> ValueBag<'v> {
 
     /// Get a value from an erased value.
     #[inline]
-    pub fn from_dyn_error(value: &'v (dyn error::Error + 'static)) -> Self {
+    pub const fn from_dyn_error(value: &'v (dyn error::Error + 'static)) -> Self {
         ValueBag {
             inner: Internal::AnonError(value),
         }

--- a/src/internal/fill.rs
+++ b/src/internal/fill.rs
@@ -3,7 +3,7 @@ use crate::{fill::Fill, ValueBag};
 
 impl<'v> ValueBag<'v> {
     /// Get a value from a fillable slot.
-    pub fn from_fill<T>(value: &'v T) -> Self
+    pub const fn from_fill<T>(value: &'v T) -> Self
     where
         T: Fill,
     {

--- a/src/internal/fmt.rs
+++ b/src/internal/fmt.rs
@@ -39,7 +39,7 @@ impl<'v> ValueBag<'v> {
     }
 
     /// Get a value from a debuggable type without capturing support.
-    pub fn from_debug<T>(value: &'v T) -> Self
+    pub const fn from_debug<T>(value: &'v T) -> Self
     where
         T: Debug,
     {
@@ -49,7 +49,7 @@ impl<'v> ValueBag<'v> {
     }
 
     /// Get a value from a displayable type without capturing support.
-    pub fn from_display<T>(value: &'v T) -> Self
+    pub const fn from_display<T>(value: &'v T) -> Self
     where
         T: Display,
     {
@@ -60,7 +60,7 @@ impl<'v> ValueBag<'v> {
 
     /// Get a value from a debuggable type without capturing support.
     #[inline]
-    pub fn from_dyn_debug(value: &'v dyn Debug) -> Self {
+    pub const fn from_dyn_debug(value: &'v dyn Debug) -> Self {
         ValueBag {
             inner: Internal::AnonDebug(value),
         }
@@ -68,7 +68,7 @@ impl<'v> ValueBag<'v> {
 
     /// Get a value from a displayable type without capturing support.
     #[inline]
-    pub fn from_dyn_display(value: &'v dyn Display) -> Self {
+    pub const fn from_dyn_display(value: &'v dyn Display) -> Self {
         ValueBag {
             inner: Internal::AnonDisplay(value),
         }

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -257,7 +257,7 @@ impl<'v> ValueBag<'v> {
 
 impl<'v> Internal<'v> {
     #[inline]
-    pub(crate) fn by_ref<'u>(&'u self) -> Internal<'u> {
+    pub(crate) const fn by_ref<'u>(&'u self) -> Internal<'u> {
         match self {
             Internal::Signed(value) => Internal::Signed(*value),
             Internal::Unsigned(value) => Internal::Unsigned(*value),

--- a/src/internal/owned.rs
+++ b/src/internal/owned.rs
@@ -40,7 +40,7 @@ pub(crate) enum OwnedInternal {
 }
 
 impl OwnedInternal {
-    pub(crate) fn by_ref<'v>(&'v self) -> Internal<'v> {
+    pub(crate) const fn by_ref<'v>(&'v self) -> Internal<'v> {
         match self {
             #[cfg(not(feature = "inline-i128"))]
             OwnedInternal::BigSigned(v) => Internal::BigSigned(v),

--- a/src/internal/serde/v1.rs
+++ b/src/internal/serde/v1.rs
@@ -27,7 +27,7 @@ impl<'v> ValueBag<'v> {
     }
 
     /// Get a value from a structured type without capturing support.
-    pub fn from_serde1<T>(value: &'v T) -> Self
+    pub const fn from_serde1<T>(value: &'v T) -> Self
     where
         T: value_bag_serde1::lib::Serialize,
     {

--- a/src/internal/sval/v2.rs
+++ b/src/internal/sval/v2.rs
@@ -25,7 +25,7 @@ impl<'v> ValueBag<'v> {
     }
 
     /// Get a value from a structured type without capturing support.
-    pub fn from_sval2<T>(value: &'v T) -> Self
+    pub const fn from_sval2<T>(value: &'v T) -> Self
     where
         T: value_bag_sval2::lib::Value,
     {
@@ -36,7 +36,7 @@ impl<'v> ValueBag<'v> {
 
     /// Get a value from a structured type without capturing support.
     #[inline]
-    pub fn from_dyn_sval2(value: &'v dyn Value) -> Self {
+    pub const fn from_dyn_sval2(value: &'v dyn Value) -> Self {
         ValueBag {
             inner: Internal::AnonSval2(value),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -425,9 +425,177 @@ pub struct ValueBag<'v> {
 }
 
 impl<'v> ValueBag<'v> {
+    /// Get an empty `ValueBag`.
+    #[inline]
+    pub const fn empty() -> ValueBag<'v> {
+        ValueBag {
+            inner: internal::Internal::None,
+        }
+    }
+
+    /// Get a `ValueBag` from a `u8`.
+    #[inline]
+    pub const fn from_u8(v: u8) -> ValueBag<'v> {
+        ValueBag {
+            inner: internal::Internal::Unsigned(v as u64)
+        }
+    }
+
+    /// Get a `ValueBag` from a `u16`.
+    #[inline]
+    pub const fn from_u16(v: u16) -> ValueBag<'v> {
+        ValueBag {
+            inner: internal::Internal::Unsigned(v as u64)
+        }
+    }
+
+    /// Get a `ValueBag` from a `u32`.
+    #[inline]
+    pub const fn from_u32(v: u32) -> ValueBag<'v> {
+        ValueBag {
+            inner: internal::Internal::Unsigned(v as u64)
+        }
+    }
+
+    /// Get a `ValueBag` from a `u64`.
+    #[inline]
+    pub const fn from_u64(v: u64) -> ValueBag<'v> {
+        ValueBag {
+            inner: internal::Internal::Unsigned(v)
+        }
+    }
+
+    /// Get a `ValueBag` from a `usize`.
+    #[inline]
+    pub const fn from_usize(v: usize) -> ValueBag<'v> {
+        ValueBag {
+            inner: internal::Internal::Unsigned(v as u64)
+        }
+    }
+
+    /// Get a `ValueBag` from a `u128`.
+    #[inline]
+    pub const fn from_u128_ref(v: &'v u128) -> ValueBag<'v> {
+        ValueBag {
+            #[cfg(not(feature = "inline-i128"))]
+            inner: internal::Internal::BigUnsigned(v),
+            #[cfg(feature = "inline-i128")]
+            inner: internal::Internal::BigUnsigned(*v),
+        }
+    }
+
+    /// Get a `ValueBag` from a `u128`.
+    #[inline]
+    #[cfg(feature = "inline-i128")]
+    pub const fn from_u128(v: u128) -> ValueBag<'v> {
+        ValueBag {
+            inner: internal::Internal::BigUnsigned(v),
+        }
+    }
+
+    /// Get a `ValueBag` from a `i8`.
+    #[inline]
+    pub const fn from_i8(v: i8) -> ValueBag<'v> {
+        ValueBag {
+            inner: internal::Internal::Signed(v as i64)
+        }
+    }
+
+    /// Get a `ValueBag` from a `i16`.
+    #[inline]
+    pub const fn from_i16(v: i16) -> ValueBag<'v> {
+        ValueBag {
+            inner: internal::Internal::Signed(v as i64)
+        }
+    }
+
+    /// Get a `ValueBag` from a `i32`.
+    #[inline]
+    pub const fn from_i32(v: i32) -> ValueBag<'v> {
+        ValueBag {
+            inner: internal::Internal::Signed(v as i64)
+        }
+    }
+
+    /// Get a `ValueBag` from a `i64`.
+    #[inline]
+    pub const fn from_i64(v: i64) -> ValueBag<'v> {
+        ValueBag {
+            inner: internal::Internal::Signed(v)
+        }
+    }
+
+    /// Get a `ValueBag` from a `isize`.
+    #[inline]
+    pub const fn from_isize(v: isize) -> ValueBag<'v> {
+        ValueBag {
+            inner: internal::Internal::Signed(v as i64)
+        }
+    }
+
+    /// Get a `ValueBag` from a `i128`.
+    #[inline]
+    pub const fn from_i128_ref(v: &'v i128) -> ValueBag<'v> {
+        ValueBag {
+            #[cfg(not(feature = "inline-i128"))]
+            inner: internal::Internal::BigSigned(v),
+            #[cfg(feature = "inline-i128")]
+            inner: internal::Internal::BigSigned(*v),
+        }
+    }
+
+    /// Get a `ValueBag` from a `i128`.
+    #[inline]
+    #[cfg(feature = "inline-i128")]
+    pub const fn from_i128(v: i128) -> ValueBag<'v> {
+        ValueBag {
+            inner: internal::Internal::BigSigned(v),
+        }
+    }
+
+    /// Get a `ValueBag` from a `f32`.
+    #[inline]
+    pub const fn from_f32(v: f32) -> ValueBag<'v> {
+        ValueBag {
+            inner: internal::Internal::Float(v as f64)
+        }
+    }
+
+    /// Get a `ValueBag` from a `f64`.
+    #[inline]
+    pub const fn from_f64(v: f64) -> ValueBag<'v> {
+        ValueBag {
+            inner: internal::Internal::Float(v)
+        }
+    }
+
+    /// Get a `ValueBag` from a `bool`.
+    #[inline]
+    pub const fn from_bool(v: bool) -> ValueBag<'v> {
+        ValueBag {
+            inner: internal::Internal::Bool(v)
+        }
+    }
+
+    /// Get a `ValueBag` from a `str`.
+    #[inline]
+    pub const fn from_str(v: &'v str) -> ValueBag<'v> {
+        ValueBag {
+            inner: internal::Internal::Str(v)
+        }
+    }
+
+    /// Get a `ValueBag` from a `char`.
+    #[inline]
+    pub const fn from_char(v: char) -> ValueBag<'v> {
+        ValueBag {
+            inner: internal::Internal::Char(v)
+        }
+    }
+
     /// Get a `ValueBag` from a reference to a `ValueBag`.
     #[inline]
-    pub fn by_ref<'u>(&'u self) -> ValueBag<'u> {
+    pub const fn by_ref<'u>(&'u self) -> ValueBag<'u> {
         ValueBag {
             inner: self.inner.by_ref(),
         }

--- a/src/owned.rs
+++ b/src/owned.rs
@@ -31,7 +31,7 @@ impl OwnedValueBag {
     /// - `fmt::Debug` won't use formatting flags.
     /// - `serde::Serialize` will use the text-based representation.
     /// - The original type will change, so downcasting won't work.
-    pub fn by_ref<'v>(&'v self) -> ValueBag<'v> {
+    pub const fn by_ref<'v>(&'v self) -> ValueBag<'v> {
         ValueBag {
             inner: self.inner.by_ref(),
         }


### PR DESCRIPTION
Closes #72

This PR adds inherent const constructors for `ValueBag` from most common primitives. Among those is a `ValueBag::empty()` method that produces the none variant.