### PR TITLE
Support capturing owned values in ValueBag<'v> itself

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
         run: cargo hack test --feature-powerset --lib
 
       - name: Minimal versions
-        run: cargo hack test --feature-powerset -Z minimal-versions
+        run: cargo hack test --feature-powerset --lib -Z minimal-versions
 
   embedded:
     name: Build (embedded)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,8 +25,11 @@ jobs:
       - name: Install cargo-hack
         run: cargo install cargo-hack
 
+      - name: All
+        run: cargo test --all-features
+
       - name: Powerset
-        run: cargo hack test --feature-powerset
+        run: cargo hack test --feature-powerset --lib
 
       - name: Minimal versions
         run: cargo hack test --feature-powerset -Z minimal-versions

--- a/src/fill.rs
+++ b/src/fill.rs
@@ -62,6 +62,13 @@ where
     }
 }
 
+#[cfg(feature = "owned")]
+impl<F: Fill + ?Sized> Fill for crate::std::sync::Arc<F> {
+    fn fill(&self, slot: Slot) -> Result<(), Error> {
+        (**self).fill(slot)
+    }
+}
+
 /// A value slot to fill using the [`Fill`](trait.Fill.html) trait.
 pub struct Slot<'s, 'f> {
     visitor: &'s mut dyn InternalVisitor<'f>,

--- a/src/fill.rs
+++ b/src/fill.rs
@@ -62,13 +62,6 @@ where
     }
 }
 
-#[cfg(feature = "owned")]
-impl<F: Fill + ?Sized> Fill for crate::std::sync::Arc<F> {
-    fn fill(&self, slot: Slot) -> Result<(), Error> {
-        (**self).fill(slot)
-    }
-}
-
 /// A value slot to fill using the [`Fill`](trait.Fill.html) trait.
 pub struct Slot<'s, 'f> {
     visitor: &'s mut dyn InternalVisitor<'f>,

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -373,41 +373,50 @@ impl<'v> TryFrom<ValueBag<'v>> for &'v str {
     }
 }
 
-impl<'v> From<&'v ()> for ValueBag<'v> {
+impl<'a, 'v> From<&'a ()> for ValueBag<'v> {
     #[inline]
-    fn from(_: &'v ()) -> Self {
+    fn from(_: &'a ()) -> Self {
         ValueBag::empty()
     }
 }
 
-impl<'v> From<&'v u8> for ValueBag<'v> {
+impl<'a, 'v> From<&'a u8> for ValueBag<'v> {
     #[inline]
-    fn from(v: &'v u8) -> Self {
+    fn from(v: &'a u8) -> Self {
         ValueBag::from_u8(*v)
     }
 }
 
-impl<'v> From<&'v u16> for ValueBag<'v> {
+impl<'a, 'v> From<&'a u16> for ValueBag<'v> {
     #[inline]
-    fn from(v: &'v u16) -> Self {
+    fn from(v: &'a u16) -> Self {
         ValueBag::from_u16(*v)
     }
 }
 
-impl<'v> From<&'v u32> for ValueBag<'v> {
+impl<'a, 'v> From<&'a u32> for ValueBag<'v> {
     #[inline]
-    fn from(v: &'v u32) -> Self {
+    fn from(v: &'a u32) -> Self {
         ValueBag::from_u32(*v)
     }
 }
 
-impl<'v> From<&'v u64> for ValueBag<'v> {
+impl<'a, 'v> From<&'a u64> for ValueBag<'v> {
     #[inline]
-    fn from(v: &'v u64) -> Self {
+    fn from(v: &'a u64) -> Self {
         ValueBag::from_u64(*v)
     }
 }
 
+#[cfg(feature = "inline-i128")]
+impl<'a, 'v> From<&'a u128> for ValueBag<'v> {
+    #[inline]
+    fn from(v: &'a u128) -> Self {
+        ValueBag::from_u128(*v)
+    }
+}
+
+#[cfg(not(feature = "inline-i128"))]
 impl<'v> From<&'v u128> for ValueBag<'v> {
     #[inline]
     fn from(v: &'v u128) -> Self {
@@ -432,41 +441,50 @@ impl<'v> TryFrom<ValueBag<'v>> for u128 {
     }
 }
 
-impl<'v> From<&'v usize> for ValueBag<'v> {
+impl<'a, 'v> From<&'a usize> for ValueBag<'v> {
     #[inline]
-    fn from(v: &'v usize) -> Self {
+    fn from(v: &'a usize) -> Self {
         ValueBag::from_usize(*v)
     }
 }
 
-impl<'v> From<&'v i8> for ValueBag<'v> {
+impl<'a, 'v> From<&'a i8> for ValueBag<'v> {
     #[inline]
-    fn from(v: &'v i8) -> Self {
+    fn from(v: &'a i8) -> Self {
         ValueBag::from_i8(*v)
     }
 }
 
-impl<'v> From<&'v i16> for ValueBag<'v> {
+impl<'a, 'v> From<&'a i16> for ValueBag<'v> {
     #[inline]
-    fn from(v: &'v i16) -> Self {
+    fn from(v: &'a i16) -> Self {
         ValueBag::from_i16(*v)
     }
 }
 
-impl<'v> From<&'v i32> for ValueBag<'v> {
+impl<'a, 'v> From<&'a i32> for ValueBag<'v> {
     #[inline]
-    fn from(v: &'v i32) -> Self {
+    fn from(v: &'a i32) -> Self {
         ValueBag::from_i32(*v)
     }
 }
 
-impl<'v> From<&'v i64> for ValueBag<'v> {
+impl<'a, 'v> From<&'a i64> for ValueBag<'v> {
     #[inline]
-    fn from(v: &'v i64) -> Self {
+    fn from(v: &'a i64) -> Self {
         ValueBag::from_i64(*v)
     }
 }
 
+#[cfg(feature = "inline-i128")]
+impl<'a, 'v> From<&'a i128> for ValueBag<'v> {
+    #[inline]
+    fn from(v: &'a i128) -> Self {
+        ValueBag::from_i128(*v)
+    }
+}
+
+#[cfg(not(feature = "inline-i128"))]
 impl<'v> From<&'v i128> for ValueBag<'v> {
     #[inline]
     fn from(v: &'v i128) -> Self {
@@ -491,37 +509,37 @@ impl<'v> TryFrom<ValueBag<'v>> for i128 {
     }
 }
 
-impl<'v> From<&'v isize> for ValueBag<'v> {
+impl<'a, 'v> From<&'a isize> for ValueBag<'v> {
     #[inline]
-    fn from(v: &'v isize) -> Self {
+    fn from(v: &'a isize) -> Self {
         ValueBag::from_isize(*v)
     }
 }
 
-impl<'v> From<&'v f32> for ValueBag<'v> {
+impl<'a, 'v> From<&'a f32> for ValueBag<'v> {
     #[inline]
-    fn from(v: &'v f32) -> Self {
+    fn from(v: &'a f32) -> Self {
         ValueBag::from_f32(*v)
     }
 }
 
-impl<'v> From<&'v f64> for ValueBag<'v> {
+impl<'a, 'v> From<&'a f64> for ValueBag<'v> {
     #[inline]
-    fn from(v: &'v f64) -> Self {
+    fn from(v: &'a f64) -> Self {
         ValueBag::from_f64(*v)
     }
 }
 
-impl<'v> From<&'v bool> for ValueBag<'v> {
+impl<'a, 'v> From<&'a bool> for ValueBag<'v> {
     #[inline]
-    fn from(v: &'v bool) -> Self {
+    fn from(v: &'a bool) -> Self {
         ValueBag::from_bool(*v)
     }
 }
 
-impl<'v> From<&'v char> for ValueBag<'v> {
+impl<'a, 'v> From<&'a char> for ValueBag<'v> {
     #[inline]
-    fn from(v: &'v char) -> Self {
+    fn from(v: &'a char) -> Self {
         ValueBag::from_char(*v)
     }
 }

--- a/src/internal/cast/mod.rs
+++ b/src/internal/cast/mod.rs
@@ -184,6 +184,11 @@ impl<'v> Internal<'v> {
 
         impl<'v> InternalVisitor<'v> for CastVisitor<'v> {
             #[inline]
+            fn fill(&mut self, v: &dyn crate::fill::Fill) -> Result<(), Error> {
+                v.fill(crate::fill::Slot::new(self))
+            }
+
+            #[inline]
             fn debug(&mut self, _: &dyn fmt::Debug) -> Result<(), Error> {
                 Ok(())
             }

--- a/src/internal/cast/mod.rs
+++ b/src/internal/cast/mod.rs
@@ -17,19 +17,7 @@ use crate::{Error, ValueBag};
 
 mod primitive;
 
-impl<'v> ValueBag<'v> {
-    /// Try capture a raw value.
-    ///
-    /// This method will return `Some` if the value is a simple primitive
-    /// that can be captured without losing its structure. In other cases
-    /// this method will return `None`.
-    pub fn try_capture<T>(value: &'v T) -> Option<Self>
-    where
-        T: ?Sized + 'static,
-    {
-        primitive::from_any(value)
-    }
-
+impl ValueBag<'static> {
     /// Try capture an owned raw value.
     ///
     /// This method will return `Some` if the value is a simple primitive
@@ -41,6 +29,20 @@ impl<'v> ValueBag<'v> {
         T: ?Sized + 'static,
     {
         primitive::from_owned_any(value)
+    }
+}
+
+impl<'v> ValueBag<'v> {
+    /// Try capture a raw value.
+    ///
+    /// This method will return `Some` if the value is a simple primitive
+    /// that can be captured without losing its structure. In other cases
+    /// this method will return `None`.
+    pub fn try_capture<T>(value: &'v T) -> Option<Self>
+    where
+        T: ?Sized + 'static,
+    {
+        primitive::from_any(value)
     }
 
     /// Try get a `u64` from this value.
@@ -146,6 +148,29 @@ impl<'v> ValueBag<'v> {
             Internal::Sval2(value) => value.as_any().downcast_ref(),
             #[cfg(feature = "serde1")]
             Internal::Serde1(value) => value.as_any().downcast_ref(),
+
+            #[cfg(feature = "owned")]
+            Internal::SharedDebug(ref value) => value.as_any().downcast_ref(),
+            #[cfg(feature = "owned")]
+            Internal::SharedDisplay(ref value) => value.as_any().downcast_ref(),
+            #[cfg(all(feature = "error", feature = "owned"))]
+            Internal::SharedError(ref value) => value.as_any().downcast_ref(),
+            #[cfg(all(feature = "serde1", feature = "owned"))]
+            Internal::SharedSerde1(ref value) => value.as_any().downcast_ref(),
+            #[cfg(all(feature = "sval2", feature = "owned"))]
+            Internal::SharedSval2(ref value) => value.as_any().downcast_ref(),
+
+            #[cfg(feature = "owned")]
+            Internal::SharedRefDebug(value) => value.as_any().downcast_ref(),
+            #[cfg(feature = "owned")]
+            Internal::SharedRefDisplay(value) => value.as_any().downcast_ref(),
+            #[cfg(all(feature = "error", feature = "owned"))]
+            Internal::SharedRefError(value) => value.as_any().downcast_ref(),
+            #[cfg(all(feature = "serde1", feature = "owned"))]
+            Internal::SharedRefSerde1(value) => value.as_any().downcast_ref(),
+            #[cfg(all(feature = "sval2", feature = "owned"))]
+            Internal::SharedRefSval2(value) => value.as_any().downcast_ref(),
+
             _ => None,
         }
     }

--- a/src/internal/cast/mod.rs
+++ b/src/internal/cast/mod.rs
@@ -30,6 +30,19 @@ impl<'v> ValueBag<'v> {
         primitive::from_any(value)
     }
 
+    /// Try capture an owned raw value.
+    ///
+    /// This method will return `Some` if the value is a simple primitive
+    /// that can be captured without losing its structure. In other cases
+    /// this method will return `None`.
+    #[cfg(feature = "owned")]
+    pub fn try_capture_owned<T>(value: &'_ T) -> Option<Self>
+    where
+        T: ?Sized + 'static,
+    {
+        primitive::from_owned_any(value)
+    }
+
     /// Try get a `u64` from this value.
     ///
     /// This method is cheap for primitive types, but may call arbitrary
@@ -66,7 +79,7 @@ impl<'v> ValueBag<'v> {
     ///
     /// This method is cheap for primitive types, but may call arbitrary
     /// serialization implementations for complex ones.
-    /// 
+    ///
     /// This method is based on standard `TryInto` conversions, and will
     /// only return `Some` if there's a guaranteed lossless conversion between
     /// the source and destination types. For a more lenient alternative, see
@@ -79,7 +92,7 @@ impl<'v> ValueBag<'v> {
     ///
     /// This method is cheap for primitive types, but may call arbitrary
     /// serialization implementations for complex ones.
-    /// 
+    ///
     /// This method is like [`ValueBag::to_f64`] except will always return
     /// a `f64`, regardless of the actual type of underlying value. For
     /// numeric types, it will use a regular `as` conversion, which may be lossy.
@@ -479,13 +492,9 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn is_empty() {
-        assert!(
-            ValueBag::from(None::<i32>).is_empty(),
-        );
+        assert!(ValueBag::from(None::<i32>).is_empty(),);
 
-        assert!(
-            ValueBag::try_capture(&None::<i32>).unwrap().is_empty(),
-        );
+        assert!(ValueBag::try_capture(&None::<i32>).unwrap().is_empty(),);
     }
 
     #[test]

--- a/src/internal/cast/mod.rs
+++ b/src/internal/cast/mod.rs
@@ -4,10 +4,7 @@
 //! but may end up executing arbitrary caller code if the value is complex.
 //! They will also attempt to downcast erased types into a primitive where possible.
 
-use crate::std::{
-    convert::{TryFrom, TryInto},
-    fmt,
-};
+use crate::std::fmt;
 
 #[cfg(feature = "alloc")]
 use crate::std::{borrow::ToOwned, string::String};

--- a/src/internal/cast/primitive.rs
+++ b/src/internal/cast/primitive.rs
@@ -92,9 +92,9 @@ pub(in crate::internal) fn from_any<'v, T: ?Sized + 'static>(value: &'v T) -> Op
 }
 
 #[cfg(feature = "owned")]
-pub(in crate::internal) fn from_owned_any<'a, 'v, T: ?Sized + 'static>(
+pub(in crate::internal) fn from_owned_any<'a, T: ?Sized + 'static>(
     value: &'a T,
-) -> Option<ValueBag<'v>> {
+) -> Option<ValueBag<'static>> {
     let type_ids = |v: VoidRef<'a>| {
         check_type_ids!(
             &'a v =>

--- a/src/internal/cast/primitive.rs
+++ b/src/internal/cast/primitive.rs
@@ -8,83 +8,118 @@ use crate::std::string::String;
 
 use crate::ValueBag;
 
-pub(in crate::internal) fn from_any<'v, T: ?Sized + 'static>(value: &'v T) -> Option<ValueBag<'v>> {
-    // NOTE: The casts for unsized values (str) are dubious here. To really do this properly
-    // we need https://github.com/rust-lang/rust/issues/81513
-    // NOTE: With some kind of const `Any::is<T>` we could do all this at compile-time
-    // Older versions of `value-bag` did this, but the infrastructure just wasn't worth
-    // the tiny performance improvement
-    use crate::std::any::TypeId;
+// NOTE: The casts for unsized values (str) are dubious here. To really do this properly
+// we need https://github.com/rust-lang/rust/issues/81513
+// NOTE: With some kind of const `Any::is<T>` we could do all this at compile-time
+// Older versions of `value-bag` did this, but the infrastructure just wasn't worth
+// the tiny performance improvement
+use crate::std::any::TypeId;
 
-    enum Void {}
+enum Void {}
 
-    #[repr(transparent)]
-    struct VoidRef<'a>(*const &'a Void);
+#[repr(transparent)]
+struct VoidRef<'a>(*const &'a Void);
 
-    macro_rules! type_ids {
-        ($(
-            $(#[cfg($($cfg:tt)*)])*
-                $ty:ty,
-            )*) => {
-            |v: VoidRef<'_>| {
-                if TypeId::of::<T>() == TypeId::of::<str>() {
-                    // SAFETY: We verify the value is str before casting
-                        let v = unsafe { *(v.0 as *const &'_ str) };
+macro_rules! check_type_ids {
+    (&$l:lifetime $v:ident => $(
+        $(#[cfg($($cfg:tt)*)])*
+            $ty:ty,
+        )*
+    ) => {
+        $(
+            $(#[cfg($($cfg)*)])*
+            if TypeId::of::<T>() == TypeId::of::<$ty>() {
+                // SAFETY: We verify the value is $ty before casting
+                let v = unsafe { *($v.0 as *const & $l $ty) };
 
-                    return Some(ValueBag::from(v));
-                }
-
-                    $(
-                        $(#[cfg($($cfg)*)])*
-                        if TypeId::of::<T>() == TypeId::of::<$ty>() {
-                            // SAFETY: We verify the value is $ty before casting
-                            let v = unsafe { *(v.0 as *const &'_ $ty) };
-
-                            return Some(ValueBag::from(v));
-                        }
-                    )*
-                    $(
-                        $(#[cfg($($cfg)*)])*
-                        if TypeId::of::<T>() == TypeId::of::<Option<$ty>>() {
-                            // SAFETY: We verify the value is Option<$ty> before casting
-                            let v = unsafe { *(v.0 as *const &'_ Option<$ty>) };
-
-                            if let Some(v) = v {
-                                return Some(ValueBag::from(v));
-                            } else {
-                                return Some(ValueBag::empty());
-                            }
-                        }
-                    )*
-
-                    None
+                return Some(ValueBag::from(v));
             }
-        };
-    }
+        )*
+        $(
+            $(#[cfg($($cfg)*)])*
+            if TypeId::of::<T>() == TypeId::of::<Option<$ty>>() {
+                // SAFETY: We verify the value is Option<$ty> before casting
+                let v = unsafe { *($v.0 as *const & $l Option<$ty>) };
 
-    let type_ids = type_ids![
-        usize,
-        u8,
-        u16,
-        u32,
-        u64,
-        u128,
-        isize,
-        i8,
-        i16,
-        i32,
-        i64,
-        i128,
-        f32,
-        f64,
-        char,
-        bool,
-        &'static str,
-        // We deal with `str` separately because it's unsized
-        // str,
-        #[cfg(feature = "alloc")]
-        String,
-    ];
+                if let Some(v) = v {
+                    return Some(ValueBag::from(v));
+                } else {
+                    return Some(ValueBag::empty());
+                }
+            }
+        )*
+    };
+}
+
+pub(in crate::internal) fn from_any<'v, T: ?Sized + 'static>(value: &'v T) -> Option<ValueBag<'v>> {
+    let type_ids = |v: VoidRef<'v>| {
+        if TypeId::of::<T>() == TypeId::of::<str>() {
+            // SAFETY: We verify the value is str before casting
+            let v = unsafe { *(v.0 as *const &'v str) };
+
+            return Some(ValueBag::from(v));
+        }
+
+        check_type_ids!(
+            &'v v =>
+                usize,
+                u8,
+                u16,
+                u32,
+                u64,
+                u128,
+                isize,
+                i8,
+                i16,
+                i32,
+                i64,
+                i128,
+                f32,
+                f64,
+                char,
+                bool,
+                &'static str,
+                // We deal with `str` separately because it's unsized
+                // str,
+                #[cfg(feature = "alloc")]
+                String,
+        );
+
+        None
+    };
 
     (type_ids)(VoidRef(&(value) as *const &'v T as *const &'v Void))
+}
+
+#[cfg(feature = "owned")]
+pub(in crate::internal) fn from_owned_any<'a, 'v, T: ?Sized + 'static>(
+    value: &'a T,
+) -> Option<ValueBag<'v>> {
+    let type_ids = |v: VoidRef<'a>| {
+        check_type_ids!(
+            &'a v =>
+                usize,
+                u8,
+                u16,
+                u32,
+                u64,
+                #[cfg(feature = "inline-i128")]
+                u128,
+                isize,
+                i8,
+                i16,
+                i32,
+                i64,
+                #[cfg(feature = "inline-i128")]
+                i128,
+                f32,
+                f64,
+                char,
+                bool,
+        );
+
+        None
+    };
+
+    (type_ids)(VoidRef(&(value) as *const &'a T as *const &'a Void))
 }

--- a/src/internal/fmt.rs
+++ b/src/internal/fmt.rs
@@ -256,7 +256,7 @@ impl<'v> Display for ValueBag<'v> {
             fn fill(&mut self, v: &dyn crate::fill::Fill) -> Result<(), Error> {
                 v.fill(crate::fill::Slot::new(self))
             }
-            
+
             fn debug(&mut self, v: &dyn Debug) -> Result<(), Error> {
                 Debug::fmt(v, self.0)?;
 

--- a/src/internal/fmt.rs
+++ b/src/internal/fmt.rs
@@ -146,6 +146,10 @@ impl<'v> Debug for ValueBag<'v> {
         struct DebugVisitor<'a, 'b: 'a>(&'a mut fmt::Formatter<'b>);
 
         impl<'a, 'b: 'a, 'v> InternalVisitor<'v> for DebugVisitor<'a, 'b> {
+            fn fill(&mut self, v: &dyn crate::fill::Fill) -> Result<(), Error> {
+                v.fill(crate::fill::Slot::new(self))
+            }
+
             fn debug(&mut self, v: &dyn Debug) -> Result<(), Error> {
                 Debug::fmt(v, self.0)?;
 
@@ -249,6 +253,10 @@ impl<'v> Display for ValueBag<'v> {
         struct DisplayVisitor<'a, 'b: 'a>(&'a mut fmt::Formatter<'b>);
 
         impl<'a, 'b: 'a, 'v> InternalVisitor<'v> for DisplayVisitor<'a, 'b> {
+            fn fill(&mut self, v: &dyn crate::fill::Fill) -> Result<(), Error> {
+                v.fill(crate::fill::Slot::new(self))
+            }
+            
             fn debug(&mut self, v: &dyn Debug) -> Result<(), Error> {
                 Debug::fmt(v, self.0)?;
 

--- a/src/internal/fmt.rs
+++ b/src/internal/fmt.rs
@@ -90,6 +90,12 @@ impl<T: fmt::Display + 'static> DowncastDisplay for T {
     }
 }
 
+impl<'a> fmt::Display for dyn DowncastDisplay + Send + Sync + 'a {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_super().fmt(f)
+    }
+}
+
 pub(crate) trait DowncastDebug {
     fn as_any(&self) -> &dyn Any;
     fn as_super(&self) -> &dyn fmt::Debug;
@@ -102,6 +108,12 @@ impl<T: fmt::Debug + 'static> DowncastDebug for T {
 
     fn as_super(&self) -> &dyn fmt::Debug {
         self
+    }
+}
+
+impl<'a> fmt::Debug for dyn DowncastDebug + Send + Sync + 'a {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_super().fmt(f)
     }
 }
 

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -3,10 +3,7 @@
 //! This implementation isn't intended to be public. It may need to change
 //! for optimizations or to support new external serialization frameworks.
 
-use crate::{
-    fill::Fill,
-    Error, ValueBag,
-};
+use crate::{fill::Fill, Error, ValueBag};
 
 pub(crate) mod cast;
 #[cfg(feature = "error")]
@@ -124,7 +121,10 @@ pub(crate) trait InternalVisitor<'v> {
         self.display(v)
     }
     #[cfg(feature = "owned")]
-    fn shared_display(&mut self, v: &Arc<dyn fmt::DowncastDisplay + Send + Sync>) -> Result<(), Error> {
+    fn shared_display(
+        &mut self,
+        v: &Arc<dyn fmt::DowncastDisplay + Send + Sync>,
+    ) -> Result<(), Error> {
         self.display(v)
     }
 
@@ -156,7 +156,10 @@ pub(crate) trait InternalVisitor<'v> {
         self.error(v)
     }
     #[cfg(all(feature = "error", feature = "owned"))]
-    fn shared_error(&mut self, v: &Arc<dyn error::DowncastError + Send + Sync>) -> Result<(), Error> {
+    fn shared_error(
+        &mut self,
+        v: &Arc<dyn error::DowncastError + Send + Sync>,
+    ) -> Result<(), Error> {
         self.error(v.as_super())
     }
 
@@ -167,7 +170,10 @@ pub(crate) trait InternalVisitor<'v> {
         self.sval2(v)
     }
     #[cfg(all(feature = "sval2", feature = "owned"))]
-    fn shared_sval2(&mut self, v: &Arc<dyn sval::v2::DowncastValue + Send + Sync>) -> Result<(), Error> {
+    fn shared_sval2(
+        &mut self,
+        v: &Arc<dyn sval::v2::DowncastValue + Send + Sync>,
+    ) -> Result<(), Error> {
         self.sval2(v.as_super())
     }
 
@@ -178,7 +184,10 @@ pub(crate) trait InternalVisitor<'v> {
         self.serde1(v)
     }
     #[cfg(all(feature = "serde1", feature = "owned"))]
-    fn shared_serde1(&mut self, v: &Arc<dyn serde::v1::DowncastSerialize + Send + Sync>) -> Result<(), Error> {
+    fn shared_serde1(
+        &mut self,
+        v: &Arc<dyn serde::v1::DowncastSerialize + Send + Sync>,
+    ) -> Result<(), Error> {
         self.serde1(v.as_super())
     }
 
@@ -220,7 +229,10 @@ impl<'a, 'v, V: InternalVisitor<'v> + ?Sized> InternalVisitor<'v> for &'a mut V 
     }
 
     #[cfg(feature = "owned")]
-    fn shared_display(&mut self, v: &Arc<dyn fmt::DowncastDisplay + Send + Sync>) -> Result<(), Error> {
+    fn shared_display(
+        &mut self,
+        v: &Arc<dyn fmt::DowncastDisplay + Send + Sync>,
+    ) -> Result<(), Error> {
         (**self).shared_display(v)
     }
 
@@ -283,7 +295,10 @@ impl<'a, 'v, V: InternalVisitor<'v> + ?Sized> InternalVisitor<'v> for &'a mut V 
     }
 
     #[cfg(all(feature = "error", feature = "owned"))]
-    fn shared_error(&mut self, v: &Arc<dyn error::DowncastError + Send + Sync>) -> Result<(), Error> {
+    fn shared_error(
+        &mut self,
+        v: &Arc<dyn error::DowncastError + Send + Sync>,
+    ) -> Result<(), Error> {
         (**self).shared_error(v)
     }
 
@@ -298,7 +313,10 @@ impl<'a, 'v, V: InternalVisitor<'v> + ?Sized> InternalVisitor<'v> for &'a mut V 
     }
 
     #[cfg(all(feature = "sval2", feature = "owned"))]
-    fn shared_sval2(&mut self, v: &Arc<dyn sval::v2::DowncastValue + Send + Sync>) -> Result<(), Error> {
+    fn shared_sval2(
+        &mut self,
+        v: &Arc<dyn sval::v2::DowncastValue + Send + Sync>,
+    ) -> Result<(), Error> {
         (**self).shared_sval2(v)
     }
 
@@ -313,7 +331,10 @@ impl<'a, 'v, V: InternalVisitor<'v> + ?Sized> InternalVisitor<'v> for &'a mut V 
     }
 
     #[cfg(all(feature = "serde1", feature = "owned"))]
-    fn shared_serde1(&mut self, v: &Arc<dyn serde::v1::DowncastSerialize + Send + Sync>) -> Result<(), Error> {
+    fn shared_serde1(
+        &mut self,
+        v: &Arc<dyn serde::v1::DowncastSerialize + Send + Sync>,
+    ) -> Result<(), Error> {
         (**self).shared_serde1(v)
     }
 

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -105,7 +105,7 @@ pub(crate) trait InternalVisitor<'v> {
 
     #[cfg(feature = "owned")]
     fn shared_fill(&mut self, v: &Arc<dyn Fill + Send + Sync>) -> Result<(), Error> {
-        self.fill(v)
+        self.fill(&**v)
     }
 
     fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error>;

--- a/src/internal/owned.rs
+++ b/src/internal/owned.rs
@@ -92,7 +92,10 @@ impl<'v> Internal<'v> {
                 v.fill(crate::fill::Slot::new(self))
             }
 
-            fn shared_fill(&mut self, v: &Arc<dyn crate::fill::Fill + Send + Sync>) -> Result<(), Error> {
+            fn shared_fill(
+                &mut self,
+                v: &Arc<dyn crate::fill::Fill + Send + Sync>,
+            ) -> Result<(), Error> {
                 self.0 = OwnedInternal::SharedFill(v.clone());
                 Ok(())
             }
@@ -102,7 +105,10 @@ impl<'v> Internal<'v> {
                 Ok(())
             }
 
-            fn shared_debug(&mut self, v: &Arc<dyn internal::fmt::DowncastDebug + Send + Sync>) -> Result<(), Error> {
+            fn shared_debug(
+                &mut self,
+                v: &Arc<dyn internal::fmt::DowncastDebug + Send + Sync>,
+            ) -> Result<(), Error> {
                 self.0 = OwnedInternal::SharedDebug(v.clone());
                 Ok(())
             }
@@ -112,7 +118,10 @@ impl<'v> Internal<'v> {
                 Ok(())
             }
 
-            fn shared_display(&mut self, v: &Arc<dyn internal::fmt::DowncastDisplay + Send + Sync>) -> Result<(), Error> {
+            fn shared_display(
+                &mut self,
+                v: &Arc<dyn internal::fmt::DowncastDisplay + Send + Sync>,
+            ) -> Result<(), Error> {
                 self.0 = OwnedInternal::SharedDisplay(v.clone());
                 Ok(())
             }
@@ -169,7 +178,10 @@ impl<'v> Internal<'v> {
             }
 
             #[cfg(feature = "error")]
-            fn shared_error(&mut self, v: &Arc<dyn internal::error::DowncastError + Send + Sync>) -> Result<(), Error> {
+            fn shared_error(
+                &mut self,
+                v: &Arc<dyn internal::error::DowncastError + Send + Sync>,
+            ) -> Result<(), Error> {
                 self.0 = OwnedInternal::SharedError(v.clone());
                 Ok(())
             }
@@ -183,7 +195,10 @@ impl<'v> Internal<'v> {
             }
 
             #[cfg(feature = "sval2")]
-            fn shared_sval2(&mut self, v: &Arc<dyn internal::sval::v2::DowncastValue + Send + Sync>) -> Result<(), Error> {
+            fn shared_sval2(
+                &mut self,
+                v: &Arc<dyn internal::sval::v2::DowncastValue + Send + Sync>,
+            ) -> Result<(), Error> {
                 self.0 = OwnedInternal::SharedSval2(v.clone());
                 Ok(())
             }
@@ -197,7 +212,10 @@ impl<'v> Internal<'v> {
             }
 
             #[cfg(feature = "serde1")]
-            fn shared_serde1(&mut self, v: &Arc<dyn internal::serde::v1::DowncastSerialize + Send + Sync>) -> Result<(), Error> {
+            fn shared_serde1(
+                &mut self,
+                v: &Arc<dyn internal::serde::v1::DowncastSerialize + Send + Sync>,
+            ) -> Result<(), Error> {
                 self.0 = OwnedInternal::SharedSerde1(v.clone());
                 Ok(())
             }

--- a/src/internal/owned.rs
+++ b/src/internal/owned.rs
@@ -167,4 +167,8 @@ impl<'v> Internal<'v> {
 
         visitor.0
     }
+
+    pub(crate) fn into_owned(self) -> OwnedInternal {
+        todo!()
+    }
 }

--- a/src/internal/serde/v1.rs
+++ b/src/internal/serde/v1.rs
@@ -877,10 +877,7 @@ mod tests {
         fn serde1_as_seq() {
             assert_eq!(
                 vec![1.0, 2.0, 3.0],
-                ValueBag::capture_serde1(&[
-                    1.0, 2.0, 3.0,
-                ])
-                .as_f64_seq::<Vec<f64>>()
+                ValueBag::capture_serde1(&[1.0, 2.0, 3.0,]).as_f64_seq::<Vec<f64>>()
             );
         }
     }

--- a/src/internal/serde/v1.rs
+++ b/src/internal/serde/v1.rs
@@ -107,7 +107,7 @@ impl<'v> value_bag_serde1::lib::Serialize for ValueBag<'v> {
             fn fill(&mut self, v: &dyn crate::fill::Fill) -> Result<(), Error> {
                 v.fill(crate::fill::Slot::new(self))
             }
-            
+
             fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error> {
                 struct DebugToDisplay<T>(T);
 

--- a/src/internal/serde/v1.rs
+++ b/src/internal/serde/v1.rs
@@ -104,6 +104,10 @@ impl<'v> value_bag_serde1::lib::Serialize for ValueBag<'v> {
         where
             S: value_bag_serde1::lib::Serializer,
         {
+            fn fill(&mut self, v: &dyn crate::fill::Fill) -> Result<(), Error> {
+                v.fill(crate::fill::Slot::new(self))
+            }
+            
             fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error> {
                 struct DebugToDisplay<T>(T);
 

--- a/src/internal/sval/v2.rs
+++ b/src/internal/sval/v2.rs
@@ -91,6 +91,10 @@ impl<'sval> value_bag_sval2::lib_ref::ValueRef<'sval> for ValueBag<'sval> {
         impl<'a, 'v, S: value_bag_sval2::lib::Stream<'v> + ?Sized> InternalVisitor<'v>
             for Sval2Visitor<'a, S>
         {
+            fn fill(&mut self, v: &dyn crate::fill::Fill) -> Result<(), Error> {
+                v.fill(crate::fill::Slot::new(self))
+            }
+
             fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error> {
                 value_bag_sval2::fmt::stream_debug(self.0, v).map_err(Error::from_sval2)
             }

--- a/src/internal/sval/v2.rs
+++ b/src/internal/sval/v2.rs
@@ -738,10 +738,7 @@ mod tests {
         fn sval2_as_seq() {
             assert_eq!(
                 vec![1.0, 2.0, 3.0],
-                ValueBag::capture_sval2(&[
-                    1.0, 2.0, 3.0,
-                ])
-                .as_f64_seq::<Vec<f64>>()
+                ValueBag::capture_sval2(&[1.0, 2.0, 3.0,]).as_f64_seq::<Vec<f64>>()
             );
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,9 +93,12 @@ extern crate alloc;
 #[allow(unused_imports)]
 mod std {
     pub use crate::{
-        alloc::{borrow, boxed, string, sync},
+        alloc::{borrow, boxed, string},
         core::*,
     };
+
+    #[cfg(feature = "owned")]
+    pub use crate::alloc::sync;
 }
 
 #[cfg(not(any(feature = "alloc", feature = "std", test)))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ extern crate alloc;
 #[allow(unused_imports)]
 mod std {
     pub use crate::{
-        alloc::{borrow, boxed, string},
+        alloc::{borrow, boxed, string, sync},
         core::*,
     };
 }
@@ -434,7 +434,7 @@ impl<'v> ValueBag<'v> {
     }
 
     /// Get a `ValueBag` from an `Option`.
-    /// 
+    ///
     /// This method will return `ValueBag::empty` if the value is `None`.
     #[inline]
     pub fn from_option(v: Option<impl Into<ValueBag<'v>>>) -> ValueBag<'v> {
@@ -448,7 +448,7 @@ impl<'v> ValueBag<'v> {
     #[inline]
     pub const fn from_u8(v: u8) -> ValueBag<'v> {
         ValueBag {
-            inner: internal::Internal::Unsigned(v as u64)
+            inner: internal::Internal::Unsigned(v as u64),
         }
     }
 
@@ -456,7 +456,7 @@ impl<'v> ValueBag<'v> {
     #[inline]
     pub const fn from_u16(v: u16) -> ValueBag<'v> {
         ValueBag {
-            inner: internal::Internal::Unsigned(v as u64)
+            inner: internal::Internal::Unsigned(v as u64),
         }
     }
 
@@ -464,7 +464,7 @@ impl<'v> ValueBag<'v> {
     #[inline]
     pub const fn from_u32(v: u32) -> ValueBag<'v> {
         ValueBag {
-            inner: internal::Internal::Unsigned(v as u64)
+            inner: internal::Internal::Unsigned(v as u64),
         }
     }
 
@@ -472,7 +472,7 @@ impl<'v> ValueBag<'v> {
     #[inline]
     pub const fn from_u64(v: u64) -> ValueBag<'v> {
         ValueBag {
-            inner: internal::Internal::Unsigned(v)
+            inner: internal::Internal::Unsigned(v),
         }
     }
 
@@ -480,7 +480,7 @@ impl<'v> ValueBag<'v> {
     #[inline]
     pub const fn from_usize(v: usize) -> ValueBag<'v> {
         ValueBag {
-            inner: internal::Internal::Unsigned(v as u64)
+            inner: internal::Internal::Unsigned(v as u64),
         }
     }
 
@@ -508,7 +508,7 @@ impl<'v> ValueBag<'v> {
     #[inline]
     pub const fn from_i8(v: i8) -> ValueBag<'v> {
         ValueBag {
-            inner: internal::Internal::Signed(v as i64)
+            inner: internal::Internal::Signed(v as i64),
         }
     }
 
@@ -516,7 +516,7 @@ impl<'v> ValueBag<'v> {
     #[inline]
     pub const fn from_i16(v: i16) -> ValueBag<'v> {
         ValueBag {
-            inner: internal::Internal::Signed(v as i64)
+            inner: internal::Internal::Signed(v as i64),
         }
     }
 
@@ -524,7 +524,7 @@ impl<'v> ValueBag<'v> {
     #[inline]
     pub const fn from_i32(v: i32) -> ValueBag<'v> {
         ValueBag {
-            inner: internal::Internal::Signed(v as i64)
+            inner: internal::Internal::Signed(v as i64),
         }
     }
 
@@ -532,7 +532,7 @@ impl<'v> ValueBag<'v> {
     #[inline]
     pub const fn from_i64(v: i64) -> ValueBag<'v> {
         ValueBag {
-            inner: internal::Internal::Signed(v)
+            inner: internal::Internal::Signed(v),
         }
     }
 
@@ -540,7 +540,7 @@ impl<'v> ValueBag<'v> {
     #[inline]
     pub const fn from_isize(v: isize) -> ValueBag<'v> {
         ValueBag {
-            inner: internal::Internal::Signed(v as i64)
+            inner: internal::Internal::Signed(v as i64),
         }
     }
 
@@ -568,7 +568,7 @@ impl<'v> ValueBag<'v> {
     #[inline]
     pub const fn from_f32(v: f32) -> ValueBag<'v> {
         ValueBag {
-            inner: internal::Internal::Float(v as f64)
+            inner: internal::Internal::Float(v as f64),
         }
     }
 
@@ -576,7 +576,7 @@ impl<'v> ValueBag<'v> {
     #[inline]
     pub const fn from_f64(v: f64) -> ValueBag<'v> {
         ValueBag {
-            inner: internal::Internal::Float(v)
+            inner: internal::Internal::Float(v),
         }
     }
 
@@ -584,7 +584,7 @@ impl<'v> ValueBag<'v> {
     #[inline]
     pub const fn from_bool(v: bool) -> ValueBag<'v> {
         ValueBag {
-            inner: internal::Internal::Bool(v)
+            inner: internal::Internal::Bool(v),
         }
     }
 
@@ -592,7 +592,7 @@ impl<'v> ValueBag<'v> {
     #[inline]
     pub const fn from_str(v: &'v str) -> ValueBag<'v> {
         ValueBag {
-            inner: internal::Internal::Str(v)
+            inner: internal::Internal::Str(v),
         }
     }
 
@@ -600,7 +600,7 @@ impl<'v> ValueBag<'v> {
     #[inline]
     pub const fn from_char(v: char) -> ValueBag<'v> {
         ValueBag {
-            inner: internal::Internal::Char(v)
+            inner: internal::Internal::Char(v),
         }
     }
 

--- a/src/owned.rs
+++ b/src/owned.rs
@@ -1,4 +1,8 @@
-use crate::{internal, ValueBag};
+use crate::{
+    internal::{self, Internal},
+    std::sync::Arc,
+    ValueBag,
+};
 
 /// A dynamic structured value.
 ///
@@ -19,6 +23,22 @@ impl<'v> ValueBag<'v> {
         OwnedValueBag {
             inner: self.inner.to_owned(),
         }
+    }
+
+    /// Get a value from an owned debuggable type.
+    #[inline]
+    pub fn from_owned_debug(value: impl internal::fmt::Debug + Send + Sync + 'static) -> Self {
+        Self::try_capture_owned(&value).unwrap_or_else(|| ValueBag {
+            inner: Internal::OwnedDebug(Arc::new(value)),
+        })
+    }
+
+    /// Get a value from an owned debuggable type.
+    #[inline]
+    pub fn from_owned_display(value: impl internal::fmt::Display + Send + Sync + 'static) -> Self {
+        Self::try_capture_owned(&value).unwrap_or_else(|| ValueBag {
+            inner: Internal::OwnedDisplay(Arc::new(value)),
+        })
     }
 }
 

--- a/src/owned.rs
+++ b/src/owned.rs
@@ -167,6 +167,17 @@ mod tests {
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn owned_fill_to_owned() {
+        let value = ValueBag::capture_owned_fill(|slot: fill::Slot| slot.fill_any(42u64)).to_owned();
+
+        assert!(matches!(
+            value.inner,
+            internal::owned::OwnedInternal::SharedFill(_),
+        ));
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn fmt_to_owned() {
         let debug = ValueBag::from_debug(&"a value").to_owned();
         let display = ValueBag::from_display(&"a value").to_owned();
@@ -188,6 +199,31 @@ mod tests {
 
         assert!(matches!(debug.inner, internal::Internal::AnonDebug(_)));
         assert!(matches!(display.inner, internal::Internal::AnonDisplay(_)));
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn owned_fmt_to_owned() {
+        let debug = ValueBag::capture_owned_debug("a value".to_string()).to_owned();
+        let display = ValueBag::capture_owned_display("a value".to_string()).to_owned();
+
+        assert!(matches!(
+            debug.inner,
+            internal::owned::OwnedInternal::SharedDebug(_)
+        ));
+        assert!(matches!(
+            display.inner,
+            internal::owned::OwnedInternal::SharedDisplay(_)
+        ));
+
+        assert_eq!("\"a value\"", debug.to_string());
+        assert_eq!("a value", display.to_string());
+
+        let debug = debug.by_ref();
+        let display = display.by_ref();
+
+        assert!(matches!(debug.inner, internal::Internal::SharedRefDebug(_)));
+        assert!(matches!(display.inner, internal::Internal::SharedRefDisplay(_)));
     }
 
     #[test]
@@ -213,6 +249,26 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "error")]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn owned_error_to_owned() {
+        use crate::std::io;
+
+        let value =
+            ValueBag::capture_owned_error(io::Error::new(io::ErrorKind::Other, "something failed!"))
+                .to_owned();
+
+        assert!(matches!(
+            value.inner,
+            internal::owned::OwnedInternal::SharedError(_)
+        ));
+
+        let value = value.by_ref();
+
+        assert!(matches!(value.inner, internal::Internal::SharedRefError(_)));
+    }
+
+    #[test]
     #[cfg(feature = "serde1")]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn serde1_to_owned() {
@@ -229,6 +285,22 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde1")]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn owned_serde1_to_owned() {
+        let value = ValueBag::capture_owned_serde1("a value".to_string()).to_owned();
+
+        assert!(matches!(
+            value.inner,
+            internal::owned::OwnedInternal::SharedSerde1(_)
+        ));
+
+        let value = value.by_ref();
+
+        assert!(matches!(value.inner, internal::Internal::SharedRefSerde1(_)));
+    }
+
+    #[test]
     #[cfg(feature = "sval2")]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn sval2_to_owned() {
@@ -242,5 +314,21 @@ mod tests {
         let value = value.by_ref();
 
         assert!(matches!(value.inner, internal::Internal::AnonSval2(_)));
+    }
+
+    #[test]
+    #[cfg(feature = "sval2")]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn owned_sval2_to_owned() {
+        let value = ValueBag::capture_owned_sval2("a value".to_string()).to_owned();
+
+        assert!(matches!(
+            value.inner,
+            internal::owned::OwnedInternal::SharedSval2(_)
+        ));
+
+        let value = value.by_ref();
+
+        assert!(matches!(value.inner, internal::Internal::SharedRefSval2(_)));
     }
 }

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -164,6 +164,11 @@ impl<'v> Internal<'v> {
 
         impl<'v, S: Default + ExtendValue<'v>> InternalVisitor<'v> for SeqVisitor<S> {
             #[inline]
+            fn fill(&mut self, v: &dyn crate::fill::Fill) -> Result<(), Error> {
+                v.fill(crate::fill::Slot::new(self))
+            }
+
+            #[inline]
             fn debug(&mut self, _: &dyn fmt::Debug) -> Result<(), Error> {
                 Ok(())
             }

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -149,6 +149,7 @@ impl<'a, S: Extend<Option<T>>, T: for<'b> TryFrom<ValueBag<'b>>> ExtendValue<'a>
     }
 }
 
+#[allow(dead_code)]
 pub(crate) trait ExtendValue<'v> {
     fn extend<'a>(&mut self, v: Internal<'a>);
 

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -61,14 +61,14 @@ impl<'v> ValueBag<'v> {
     }
 
     /// Get a collection `S` of `f64`s from this value.
-    /// 
+    ///
     /// If this value is a sequence then the collection `S` will be extended
     /// with the conversion of each of its elements. The conversion is the
     /// same as [`ValueBag::as_f64`].
-    /// 
+    ///
     /// If this value is not a sequence then this method will return an
     /// empty collection.
-    /// 
+    ///
     /// This is similar to [`ValueBag::to_f64_seq`], but can be more
     /// convenient when there's no need to distinguish between an empty
     /// collection and a non-collection, or between `f64` and non-`f64` elements.
@@ -82,7 +82,10 @@ impl<'v> ValueBag<'v> {
             }
         }
 
-        self.inner.seq::<ExtendF64<S>>().map(|seq| seq.0).unwrap_or_default()
+        self.inner
+            .seq::<ExtendF64<S>>()
+            .map(|seq| seq.0)
+            .unwrap_or_default()
     }
 
     /// Try get a collection `S` of `bool`s from this value.

--- a/src/test.rs
+++ b/src/test.rs
@@ -7,10 +7,12 @@ use crate::{
     Error, ValueBag,
 };
 
+#[cfg(test)]
 pub(crate) trait IntoValueBag<'v> {
     fn into_value_bag(self) -> ValueBag<'v>;
 }
 
+#[cfg(test)]
 impl<'v, T> IntoValueBag<'v> for T
 where
     T: Into<ValueBag<'v>>,

--- a/src/test.rs
+++ b/src/test.rs
@@ -62,6 +62,10 @@ impl<'v> ValueBag<'v> {
         struct TestVisitor(Option<TestToken>);
 
         impl<'v> internal::InternalVisitor<'v> for TestVisitor {
+            fn fill(&mut self, v: &dyn crate::fill::Fill) -> Result<(), Error> {
+                v.fill(crate::fill::Slot::new(self))
+            }
+            
             fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error> {
                 self.0 = Some(TestToken::Str(format!("{:?}", v)));
                 Ok(())

--- a/src/test.rs
+++ b/src/test.rs
@@ -65,7 +65,7 @@ impl<'v> ValueBag<'v> {
             fn fill(&mut self, v: &dyn crate::fill::Fill) -> Result<(), Error> {
                 v.fill(crate::fill::Slot::new(self))
             }
-            
+
             fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error> {
                 self.0 = Some(TestToken::Str(format!("{:?}", v)));
                 Ok(())

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -243,7 +243,7 @@ impl<'v> ValueBag<'v> {
             fn fill(&mut self, v: &dyn crate::fill::Fill) -> Result<(), Error> {
                 v.fill(crate::fill::Slot::new(self))
             }
-            
+
             fn debug(&mut self, v: &dyn internal::fmt::Debug) -> Result<(), Error> {
                 self.0.visit_any(ValueBag::from_dyn_debug(v))
             }

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -240,6 +240,10 @@ impl<'v> ValueBag<'v> {
         where
             V: Visit<'v>,
         {
+            fn fill(&mut self, v: &dyn crate::fill::Fill) -> Result<(), Error> {
+                v.fill(crate::fill::Slot::new(self))
+            }
+            
             fn debug(&mut self, v: &dyn internal::fmt::Debug) -> Result<(), Error> {
                 self.0.visit_any(ValueBag::from_dyn_debug(v))
             }


### PR DESCRIPTION
Closes #69 

This PR makes it possible to stash an owned value in a `ValueBag<'v>` itself without first needing to buffer it. The main motivation for this is to support short-term buffering in `log`'s key-value API, where users who want to build a `log::kv::Source` need to fully buffer all key-value pairs first due to lifetime constraints. This new functionality could be used to only require buffering a single key-value pair at a time by making it easy to produce a `ValueBag<'static>`.