### PR TITLE
prepare for 1.8.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "value-bag"
-version = "1.7.0"
+version = "1.8.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
@@ -73,12 +73,12 @@ error = [
 test = ["std"]
 
 [dependencies.value-bag-sval2]
-version = "1.7.0"
+version = "1.8.0"
 path = "meta/sval2"
 optional = true
 
 [dependencies.value-bag-serde1]
-version = "1.7.0"
+version = "1.8.0"
 path = "meta/serde1"
 optional = true
 

--- a/README.md
+++ b/README.md
@@ -69,20 +69,20 @@ Add the `value-bag` crate to your `Cargo.toml`:
 
 ```rust
 [dependencies.value-bag]
-version = "1.7.0"
+version = "1.8.0"
 ```
 
 You'll probably also want to add a feature for either `sval` (if you're in a no-std environment) or `serde` (if you need to integrate with other code that uses `serde`):
 
 ```rust
 [dependencies.value-bag]
-version = "1.7.0"
+version = "1.8.0"
 features = ["sval2"]
 ```
 
 ```rust
 [dependencies.value-bag]
-version = "1.7.0"
+version = "1.8.0"
 features = ["serde1"]
 ```
 

--- a/meta/serde1/Cargo.toml
+++ b/meta/serde1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "value-bag-serde1"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2021"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0 OR MIT"

--- a/meta/sval2/Cargo.toml
+++ b/meta/sval2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "value-bag-sval2"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2021"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0 OR MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! The producer of a [`ValueBag`] may use a different strategy for capturing than the eventual
 //! consumer. They don't need to coordinate directly.
 
-#![doc(html_root_url = "https://docs.rs/value-bag/1.7.0")]
+#![doc(html_root_url = "https://docs.rs/value-bag/1.8.0")]
 #![no_std]
 
 /*


### PR DESCRIPTION
## What's Changed
* Support capturing owned values in ValueBag<'v> itself by @KodrAus in https://github.com/sval-rs/value-bag/pull/84
* Support capturing sequences without a serialization framework by @KodrAus in https://github.com/sval-rs/value-bag/pull/86