### PR TITLE
Fix up how visitor does fallback on sval or serde

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,22 @@ impl Error {
             inner: Inner::Msg(msg),
         }
     }
+
+    #[cfg(feature = "serde1")]
+    pub(crate) fn try_boxed(msg: &'static str, e: impl fmt::Display) -> Self {
+        #[cfg(feature = "std")]
+        {
+            use crate::std::string::ToString;
+
+            let _ = msg;
+            Error::boxed(e.to_string())
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            let _ = e;
+            Error::msg(msg)
+        }
+    }
 }
 
 impl fmt::Display for Error {

--- a/src/fill.rs
+++ b/src/fill.rs
@@ -134,18 +134,6 @@ mod tests {
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn fill_value_owned() {
-        struct TestFill;
-
-        impl Fill for TestFill {
-            fn fill(&self, slot: Slot) -> Result<(), Error> {
-                slot.fill_any("a string")
-            }
-        }
-    }
-
-    #[test]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn fill_cast() {
         struct TestFill;
 

--- a/src/internal/cast/mod.rs
+++ b/src/internal/cast/mod.rs
@@ -275,18 +275,30 @@ impl<'v> Internal<'v> {
             #[cfg(feature = "sval2")]
             #[inline]
             fn sval2(&mut self, v: &dyn super::sval::v2::Value) -> Result<(), Error> {
-                super::sval::v2::internal_visit(v, self)
+                if super::sval::v2::internal_visit(v, self) {
+                    Ok(())
+                } else {
+                    Err(Error::msg("invalid cast"))
+                }
             }
 
             #[cfg(feature = "sval2")]
             fn borrowed_sval2(&mut self, v: &'v dyn super::sval::v2::Value) -> Result<(), Error> {
-                super::sval::v2::borrowed_internal_visit(v, self)
+                if super::sval::v2::borrowed_internal_visit(v, self) {
+                    Ok(())
+                } else {
+                    Err(Error::msg("invalid cast"))
+                }
             }
 
             #[cfg(feature = "serde1")]
             #[inline]
             fn serde1(&mut self, v: &dyn super::serde::v1::Serialize) -> Result<(), Error> {
-                super::serde::v1::internal_visit(v, self)
+                if super::serde::v1::internal_visit(v, self) {
+                    Ok(())
+                } else {
+                    Err(Error::msg("invalid cast"))
+                }
             }
 
             #[cfg(feature = "seq")]

--- a/src/internal/sval/v2.rs
+++ b/src/internal/sval/v2.rs
@@ -226,32 +226,25 @@ where
     value_bag_sval2::serde1::serialize(s, v)
 }
 
-pub(crate) fn internal_visit<'v>(
-    v: &dyn Value,
-    visitor: &mut dyn InternalVisitor<'v>,
-) -> Result<(), Error> {
+pub(crate) fn internal_visit<'v>(v: &dyn Value, visitor: &mut dyn InternalVisitor<'v>) -> bool {
     let mut visitor = VisitorStream {
         visitor,
         text_buf: Default::default(),
     };
 
-    value_bag_sval2::lib::stream_computed(&mut visitor, v).map_err(Error::from_sval2)?;
-
-    Ok(())
+    value_bag_sval2::lib::stream_computed(&mut visitor, v).is_ok()
 }
 
 pub(crate) fn borrowed_internal_visit<'v>(
     v: &'v dyn Value,
     visitor: &mut dyn InternalVisitor<'v>,
-) -> Result<(), Error> {
+) -> bool {
     let mut visitor = VisitorStream {
         visitor,
         text_buf: Default::default(),
     };
 
-    value_bag_sval2::lib::stream(&mut visitor, v).map_err(Error::from_sval2)?;
-
-    Ok(())
+    value_bag_sval2::lib::stream(&mut visitor, v).is_ok()
 }
 
 struct VisitorStream<'a, 'v> {


### PR DESCRIPTION
If a `Visit` attempted to visit a `serde` or `sval` value containing a complex type it would return an error instead of falling back to `visit_any`. This PR fixes that up.