### PR TITLE
Inline small strings in owned values

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -99,13 +99,12 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MSRV_TOOLCHAIN: 1.61.0
-      MSRV_FEATURES: "std owned seq sval2 serde1"
     steps:
       - name: Checkout sources
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
 
       - name: Default features
-        run: cargo +$MSRV_TOOLCHAIN build --features $MSRV_FEATURES
+        run: cargo +$MSRV_TOOLCHAIN build --features "std owned seq sval2 serde1"
 
   miri:
     name: Test (miri)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,10 +29,10 @@ jobs:
         run: cargo test --all-features
 
       - name: Powerset
-        run: cargo hack test --feature-powerset --lib
+        run: cargo hack test --feature-powerset --depth 4 --lib
 
       - name: Minimal versions
-        run: cargo hack test --feature-powerset --lib -Z minimal-versions
+        run: cargo hack test --feature-powerset --depth 4 --lib -Z minimal-versions
 
   embedded:
     name: Build (embedded)
@@ -66,7 +66,7 @@ jobs:
         run: cargo install cargo-hack
 
       - name: Powerset
-        run: cargo hack check --feature-powerset -Z avoid-dev-deps
+        run: cargo hack check --feature-powerset --depth 4 -Z avoid-dev-deps
 
   benches:
     name: Build (benches)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -94,6 +94,19 @@ jobs:
       - name: All features
         run: wasm-pack test --node -- --all-features
 
+  msrv:
+    name: Test (MSRV)
+    runs-on: ubuntu-latest
+    env:
+      MSRV_TOOLCHAIN: 1.61.0
+      MSRV_FEATURES: "std owned seq sval2 serde1"
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+
+      - name: Default features
+        run: cargo +$MSRV_TOOLCHAIN build --features $MSRV_FEATURES
+
   miri:
     name: Test (miri)
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ members = [
 # Store 128bit numbers inline instead of as references
 # This may increase the size of `ValueBag` on some platforms
 inline-i128 = []
+# Store small strings inline instead of as references
+# This requires a more recent Rust toolchain
+inline-str = []
 
 # Use the standard library
 std = [

--- a/benches/owned.rs
+++ b/benches/owned.rs
@@ -20,6 +20,27 @@ fn str_to_owned(b: &mut test::Bencher) {
 }
 
 #[bench]
+fn str_to_owned_clone(b: &mut test::Bencher) {
+    let bag = ValueBag::from("a string").to_owned();
+
+    b.iter(|| bag.clone());
+}
+
+#[bench]
+fn str_to_shared(b: &mut test::Bencher) {
+    let bag = ValueBag::from("a string");
+
+    b.iter(|| bag.to_shared());
+}
+
+#[bench]
+fn str_to_shared_clone(b: &mut test::Bencher) {
+    let bag = ValueBag::from("a string").to_shared();
+
+    b.iter(|| bag.clone());
+}
+
+#[bench]
 fn display_to_owned(b: &mut test::Bencher) {
     let bag = ValueBag::from_display(&42);
 

--- a/src/internal/owned.rs
+++ b/src/internal/owned.rs
@@ -1,6 +1,6 @@
 use crate::{
     internal::{self, Internal, InternalVisitor},
-    std::{boxed::Box, fmt, slice, sync::Arc},
+    std::{boxed::Box, fmt, slice, str, sync::Arc},
     Error,
 };
 

--- a/src/internal/owned.rs
+++ b/src/internal/owned.rs
@@ -1,6 +1,6 @@
 use crate::{
     internal::{self, Internal, InternalVisitor},
-    std::{boxed::Box, sync::Arc},
+    std::{boxed::Box, fmt, slice, sync::Arc},
     Error,
 };
 
@@ -12,6 +12,7 @@ pub(crate) enum OwnedInternal {
     Float(f64),
     Bool(bool),
     Char(char),
+    StrSmall(InlineStr),
     Str(Box<str>),
     None,
 
@@ -59,6 +60,7 @@ impl OwnedInternal {
             OwnedInternal::Bool(v) => Internal::Bool(*v),
             OwnedInternal::Char(v) => Internal::Char(*v),
             OwnedInternal::Str(v) => Internal::Str(v),
+            OwnedInternal::StrSmall(v) => Internal::Str(v.get()),
             OwnedInternal::None => Internal::None,
 
             OwnedInternal::Debug(v) => Internal::AnonDebug(v),
@@ -96,6 +98,7 @@ impl OwnedInternal {
             OwnedInternal::Bool(v) => OwnedInternal::Bool(v),
             OwnedInternal::Char(v) => OwnedInternal::Char(v),
             OwnedInternal::Str(v) => OwnedInternal::Str(v),
+            OwnedInternal::StrSmall(v) => OwnedInternal::StrSmall(v),
             OwnedInternal::None => OwnedInternal::None,
 
             OwnedInternal::Debug(v) => OwnedInternal::SharedDebug(Arc::new(v)),
@@ -196,7 +199,11 @@ impl<'v> Internal<'v> {
             }
 
             fn str(&mut self, v: &str) -> Result<(), Error> {
-                self.0 = OwnedInternal::Str(v.into());
+                if v.len() <= MAX_INLINE_LEN {
+                    self.0 = OwnedInternal::StrSmall(InlineStr::copy_from(v));
+                } else {
+                    self.0 = OwnedInternal::Str(v.into());
+                }
                 Ok(())
             }
 
@@ -282,5 +289,67 @@ impl<'v> Internal<'v> {
         let _ = self.internal_visit(&mut visitor);
 
         visitor.0
+    }
+}
+
+const MAX_INLINE_LEN: usize = 22;
+
+#[derive(Clone, Copy)]
+pub(crate) struct InlineStr {
+    data: [u8; MAX_INLINE_LEN],
+    len: u8,
+}
+
+impl fmt::Debug for InlineStr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(self.get(), f)
+    }
+}
+
+impl fmt::Display for InlineStr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self.get(), f)
+    }
+}
+
+impl InlineStr {
+    fn copy_from(str: &str) -> Self {
+        debug_assert!(str.len() <= MAX_INLINE_LEN);
+
+        let str = str.as_bytes();
+
+        let mut data = [0; MAX_INLINE_LEN];
+        data[..str.len()].copy_from_slice(str);
+
+        InlineStr {
+            data,
+            len: str.len() as u8,
+        }
+    }
+
+    const fn get(&self) -> &str {
+        // NOTE: We can't slice data in `const` fns yet, so we do it this way
+        // SAFETY: `data` contains valid UTF8, and `len` points within `data`
+        unsafe {
+            str::from_utf8_unchecked(slice::from_raw_parts(
+                &self.data as *const u8,
+                self.len as usize,
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::string::ToString;
+
+    #[test]
+    fn inline_str() {
+        let s = InlineStr::copy_from("abc");
+
+        assert_eq!("abc", s.get());
+        assert_eq!("abc", s.to_string());
     }
 }

--- a/src/internal/owned.rs
+++ b/src/internal/owned.rs
@@ -1,6 +1,6 @@
 use crate::{
     internal::{self, Internal, InternalVisitor},
-    std::{boxed::Box, fmt, slice, str, sync::Arc},
+    std::{boxed::Box, sync::Arc},
     Error,
 };
 
@@ -12,7 +12,8 @@ pub(crate) enum OwnedInternal {
     Float(f64),
     Bool(bool),
     Char(char),
-    StrSmall(InlineStr),
+    #[cfg(feature = "inline-str")]
+    StrSmall(inline_str::InlineStr),
     Str(Box<str>),
     None,
 
@@ -60,6 +61,7 @@ impl OwnedInternal {
             OwnedInternal::Bool(v) => Internal::Bool(*v),
             OwnedInternal::Char(v) => Internal::Char(*v),
             OwnedInternal::Str(v) => Internal::Str(v),
+            #[cfg(feature = "inline-str")]
             OwnedInternal::StrSmall(v) => Internal::Str(v.get()),
             OwnedInternal::None => Internal::None,
 
@@ -98,6 +100,7 @@ impl OwnedInternal {
             OwnedInternal::Bool(v) => OwnedInternal::Bool(v),
             OwnedInternal::Char(v) => OwnedInternal::Char(v),
             OwnedInternal::Str(v) => OwnedInternal::Str(v),
+            #[cfg(feature = "inline-str")]
             OwnedInternal::StrSmall(v) => OwnedInternal::StrSmall(v),
             OwnedInternal::None => OwnedInternal::None,
 
@@ -199,11 +202,15 @@ impl<'v> Internal<'v> {
             }
 
             fn str(&mut self, v: &str) -> Result<(), Error> {
-                if v.len() <= MAX_INLINE_LEN {
-                    self.0 = OwnedInternal::StrSmall(InlineStr::copy_from(v));
-                } else {
-                    self.0 = OwnedInternal::Str(v.into());
+                #[cfg(feature = "inline-str")]
+                {
+                    if v.len() <= inline_str::MAX_INLINE_LEN {
+                        self.0 = OwnedInternal::StrSmall(inline_str::InlineStr::copy_from(v));
+                        return Ok(());
+                    }
                 }
+
+                self.0 = OwnedInternal::Str(v.into());
                 Ok(())
             }
 
@@ -292,64 +299,68 @@ impl<'v> Internal<'v> {
     }
 }
 
-const MAX_INLINE_LEN: usize = 22;
+#[cfg(feature = "inline-str")]
+mod inline_str {
+    use crate::std::{fmt, slice, str};
 
-#[derive(Clone, Copy)]
-pub(crate) struct InlineStr {
-    data: [u8; MAX_INLINE_LEN],
-    len: u8,
-}
+    pub(super) const MAX_INLINE_LEN: usize = 22;
 
-impl fmt::Debug for InlineStr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(self.get(), f)
+    #[derive(Clone, Copy)]
+    pub(crate) struct InlineStr {
+        data: [u8; MAX_INLINE_LEN],
+        len: u8,
     }
-}
 
-impl fmt::Display for InlineStr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(self.get(), f)
-    }
-}
-
-impl InlineStr {
-    fn copy_from(str: &str) -> Self {
-        debug_assert!(str.len() <= MAX_INLINE_LEN);
-
-        let str = str.as_bytes();
-
-        let mut data = [0; MAX_INLINE_LEN];
-        data[..str.len()].copy_from_slice(str);
-
-        InlineStr {
-            data,
-            len: str.len() as u8,
+    impl fmt::Debug for InlineStr {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fmt::Debug::fmt(self.get(), f)
         }
     }
 
-    const fn get(&self) -> &str {
-        // NOTE: We can't slice data in `const` fns yet, so we do it this way
-        // SAFETY: `data` contains valid UTF8, and `len` points within `data`
-        unsafe {
-            str::from_utf8_unchecked(slice::from_raw_parts(
-                &self.data as *const u8,
-                self.len as usize,
-            ))
+    impl fmt::Display for InlineStr {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fmt::Display::fmt(self.get(), f)
         }
     }
-}
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+    impl InlineStr {
+        pub(super) fn copy_from(str: &str) -> Self {
+            let str = str.as_bytes();
 
-    use std::string::ToString;
+            // NOTE: This will panic if the string is too big
+            let mut data = [0; MAX_INLINE_LEN];
+            data[..str.len()].copy_from_slice(str);
 
-    #[test]
-    fn inline_str() {
-        let s = InlineStr::copy_from("abc");
+            InlineStr {
+                data,
+                len: str.len() as u8,
+            }
+        }
 
-        assert_eq!("abc", s.get());
-        assert_eq!("abc", s.to_string());
+        pub(super) const fn get(&self) -> &str {
+            // NOTE: We can't slice data in `const` fns yet, so we do it this way
+            // SAFETY: `data` contains valid UTF8, and `len` points within `data`
+            unsafe {
+                str::from_utf8_unchecked(slice::from_raw_parts(
+                    &self.data as *const u8,
+                    self.len as usize,
+                ))
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        use std::string::ToString;
+
+        #[test]
+        fn inline_str() {
+            let s = InlineStr::copy_from("abc");
+
+            assert_eq!("abc", s.get());
+            assert_eq!("abc", s.to_string());
+        }
     }
 }


### PR DESCRIPTION
This PR optimizes `ValueBag::to_owned` and `ValueBag::to_shared` for small strings by inlining instead of allocating for them. The difference is more significant for shared strings, because it's significantly cheaper to copy a few bytes than it is to clone an `Arc`.