### PR TITLE
Bump dependency `sval_buffer` to v2.3

### DIFF
--- a/meta/sval2/Cargo.toml
+++ b/meta/sval2/Cargo.toml
@@ -49,7 +49,7 @@ version = "2.1"
 default-features = false
 
 [dependencies.sval_buffer]
-version = "2.1"
+version = "2.3"
 default-features = false
 
 [dependencies.sval_fmt]


### PR DESCRIPTION
I'm using `cargo +nightly update -Z minimal-versions` to [check MSRV in my personal project `spdlog-rs`](https://github.com/SpriteOvO/spdlog-rs/blob/98cbfd2540a5c29c3b0a812fc12b2d2061918ff7/.github/workflows/ci.yml#L201-L204).

This cargo subcommand will resolve the version of `sval_buffer` to v2.1.1 into `Cargo.lock`. However, rustc complains errors for this version:

```
error[E0599]: no function or associated item named `collect_owned` found for struct `value_bag_sval2::sval_buffer::Value` in the current scope
   --> ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/value-bag-1.10.0/src/internal/sval/v2.rs:584:21
    |
584 |         OwnedValue::collect_owned(v)
    |                     ^^^^^^^^^^^^^ function or associated item not found in `Value<'static>`

error[E0277]: `*const str` cannot be shared between threads safely
   --> ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/value-bag-1.10.0/src/internal/owned.rs:108:67
    |
108 |             OwnedInternal::Sval2(v) => OwnedInternal::SharedSval2(Arc::new(v)),
    |                                                                   ^^^^^^^^^^^ `*const str` cannot be shared between threads safely
```

This indicates that `value-bag` depends on something that exists after `sval_buffer` v2.1.1. This PR bumps the version to the proper version v2.3 in `Cargo.toml`.