### PR TITLE
Use serde_core instead of serde

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -111,7 +111,7 @@ jobs:
     name: Test (MSRV)
     runs-on: ubuntu-latest
     env:
-      MSRV_TOOLCHAIN: 1.61.0
+      MSRV_TOOLCHAIN: 1.68.0
     steps:
       - name: Checkout sources
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab

--- a/meta/serde1/Cargo.toml
+++ b/meta/serde1/Cargo.toml
@@ -8,7 +8,7 @@ description = "Implementation detail for value-bag"
 
 [features]
 std = [
-    "serde/std",
+    "serde_core/std",
     "erased-serde/std",
 ]
 
@@ -26,7 +26,7 @@ test = [
     "serde_test",
 ]
 
-[dependencies.serde]
+[dependencies.serde_core]
 version = "1"
 features = ["alloc"]
 default-features = false

--- a/meta/serde1/Cargo.toml
+++ b/meta/serde1/Cargo.toml
@@ -32,7 +32,7 @@ features = ["alloc"]
 default-features = false
 
 [dependencies.erased-serde]
-version = "0.4"
+version = "0.4.9"
 features = ["alloc"]
 default-features = false
 

--- a/meta/serde1/src/lib.rs
+++ b/meta/serde1/src/lib.rs
@@ -5,7 +5,7 @@ Implementation detail for `value-bag`; it should not be depended on directly.
 #![no_std]
 
 pub use erased_serde as erased;
-pub use serde as lib;
+pub use serde_core as lib;
 pub use serde_fmt as fmt;
 
 #[cfg(feature = "owned")]

--- a/src/internal/owned.rs
+++ b/src/internal/owned.rs
@@ -47,7 +47,7 @@ pub(crate) enum OwnedInternal {
 
 impl OwnedInternal {
     #[inline]
-    pub(crate) const fn by_ref(&self) -> Internal {
+    pub(crate) const fn by_ref(&self) -> Internal<'_> {
         match self {
             #[cfg(not(feature = "inline-i128"))]
             OwnedInternal::BigSigned(v) => Internal::BigSigned(v),

--- a/src/owned.rs
+++ b/src/owned.rs
@@ -154,7 +154,7 @@ impl OwnedValueBag {
     /// - `fmt::Debug` won't use formatting flags.
     /// - `serde::Serialize` will use the text-based representation.
     /// - The original type may change, so downcasting can stop producing results.
-    pub const fn by_ref(&self) -> ValueBag {
+    pub const fn by_ref(&self) -> ValueBag<'_> {
         ValueBag {
             inner: self.inner.by_ref(),
         }

--- a/src/test.rs
+++ b/src/test.rs
@@ -3,9 +3,11 @@
 use crate::{
     internal,
     std::{fmt, str, string::String},
-    visit::Visit,
     Error, ValueBag,
 };
+
+#[cfg(test)]
+use crate::visit::Visit;
 
 #[cfg(test)]
 pub(crate) trait IntoValueBag<'v> {
@@ -163,6 +165,7 @@ impl<'v> ValueBag<'v> {
     }
 }
 
+#[cfg(test)]
 pub(crate) struct TestVisit {
     pub i64: i64,
     pub u64: u64,
@@ -175,6 +178,7 @@ pub(crate) struct TestVisit {
     pub char: char,
 }
 
+#[cfg(test)]
 impl Default for TestVisit {
     fn default() -> Self {
         TestVisit {
@@ -191,6 +195,7 @@ impl Default for TestVisit {
     }
 }
 
+#[cfg(test)]
 impl<'v> Visit<'v> for TestVisit {
     fn visit_any(&mut self, v: ValueBag) -> Result<(), Error> {
         panic!("unexpected value: {}", v)


### PR DESCRIPTION
This PR replaces our usage of `serde` with `serde_core`. It _might_ help with #100.