### PR TITLE
Port benches to criterion

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -123,7 +123,7 @@ jobs:
     name: Test (miri)
     runs-on: ubuntu-latest
     env:
-      MIRI_TOOLCHAIN: nightly-2023-03-26
+      MIRI_TOOLCHAIN: nightly
     steps:
       - name: Checkout sources
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -111,7 +111,7 @@ jobs:
     name: Test (MSRV)
     runs-on: ubuntu-latest
     env:
-      MSRV_TOOLCHAIN: 1.68.0
+      MSRV_TOOLCHAIN: 1.71.0
     steps:
       - name: Checkout sources
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ version = "0.2"
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies.wasm-bindgen-test]
 version = "0.3"
 
-[dev-dependencies.criterion]
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies.criterion]
 version = "0.8"
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,3 +98,22 @@ version = "0.2"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies.wasm-bindgen-test]
 version = "0.3"
+
+[dev-dependencies.criterion]
+version = "0.8"
+
+[[bench]]
+name = "by_ref"
+harness = false
+
+[[bench]]
+name = "capture"
+harness = false
+
+[[bench]]
+name = "owned"
+harness = false
+
+[[bench]]
+name = "seq"
+harness = false

--- a/benches/by_ref.rs
+++ b/benches/by_ref.rs
@@ -1,11 +1,15 @@
-#![feature(test)]
-
-extern crate test;
-
 use value_bag::ValueBag;
 
-#[bench]
-fn u8_by_ref(b: &mut test::Bencher) {
-    let v = ValueBag::from(1u8);
-    b.iter(|| v.by_ref())
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("by_ref u8", |b| {
+        let v = ValueBag::from(1u8);
+
+        b.iter(|| black_box(v.by_ref()))
+    });
 }
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/capture.rs
+++ b/benches/capture.rs
@@ -1,109 +1,96 @@
-#![feature(test)]
-
-extern crate test;
-
 use value_bag::ValueBag;
 
-#[bench]
-fn u8_capture_from(b: &mut test::Bencher) {
-    b.iter(|| ValueBag::from(1u8))
-}
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
 
-#[bench]
-fn u8_capture_debug(b: &mut test::Bencher) {
-    b.iter(|| ValueBag::capture_debug(&1u8))
-}
-
-#[bench]
-fn str_capture_debug(b: &mut test::Bencher) {
-    // Currently at the top of the linear list of types in `cast::primitive`
-    b.iter(|| ValueBag::capture_debug(&"a string"))
-}
-
-#[bench]
-fn bool_capture_debug(b: &mut test::Bencher) {
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("capture u8 from", |b| {
+        b.iter(|| black_box(ValueBag::from(1u8)))
+    });
+    c.bench_function("capture u8 debug", |b| {
+        b.iter(|| black_box(ValueBag::capture_debug(&1u8)))
+    });
+    c.bench_function("capture string debug", |b| {
+        b.iter(|| black_box(ValueBag::capture_debug(&"a string")))
+    });
     // Currently at the bottom of the linear list of types in `cast::primitive`
-    b.iter(|| ValueBag::capture_debug(&true))
-}
-
-#[bench]
-fn custom_capture_debug(b: &mut test::Bencher) {
-    #[derive(Debug)]
-    struct A;
-
-    b.iter(|| ValueBag::capture_debug(&A))
-}
-
-#[bench]
-fn fill_debug(b: &mut test::Bencher) {
-    b.iter(|| {
-        ValueBag::from_fill(&|slot: value_bag::fill::Slot| {
+    c.bench_function("capture bool debug", |b| {
+        b.iter(|| black_box(ValueBag::capture_debug(&true)))
+    });
+    c.bench_function("capture custom debug", |b| {
+        b.iter(|| {
             #[derive(Debug)]
             struct A;
 
-            slot.fill_debug(&A)
+            black_box(ValueBag::capture_debug(&A))
         })
-    })
+    });
+
+    c.bench_function("fill custom debug", |b| {
+        b.iter(|| {
+            black_box(ValueBag::from_fill(&|slot: value_bag::fill::Slot| {
+                #[derive(Debug)]
+                struct A;
+
+                slot.fill_debug(&A)
+            }))
+        })
+    });
+
+    c.bench_function("capture u8 debug to u64", |b| {
+        let v = ValueBag::from(1u8);
+
+        b.iter(|| black_box(v.to_u64()))
+    });
+
+    c.bench_function("fill u8 debug to u64", |b| {
+        let v = ValueBag::from_fill(&|slot: value_bag::fill::Slot| slot.fill_any(1u8));
+
+        b.iter(|| black_box(v.to_u64()))
+    });
+
+    c.bench_function("capture u8 debug to borrowed str", |b| {
+        let v = ValueBag::capture_debug(&1u8);
+
+        b.iter(|| black_box(v.to_borrowed_str()))
+    });
+
+    c.bench_function("capture str debug to borrowed str", |b| {
+        let v = ValueBag::capture_debug(&"a string");
+
+        b.iter(|| black_box(v.to_borrowed_str()))
+    });
+
+    c.bench_function("capture str debug to u64", |b| {
+        let v = ValueBag::capture_debug(&"a string");
+
+        b.iter(|| black_box(v.to_u64()))
+    });
+
+    c.bench_function("capture custom debug to borrowed str", |b| {
+        #[derive(Debug)]
+        struct A;
+
+        let v = ValueBag::capture_debug(&A);
+
+        b.iter(|| black_box(v.to_borrowed_str()))
+    });
+
+    #[cfg(feature = "sval2")]
+    {
+        c.bench_function("capture u8 sval to u64", |b| {
+            let v = ValueBag::from_sval2(&1u8);
+
+            b.iter(|| black_box(v.to_u64()))
+        });
+
+        c.bench_function("fill u8 sval to u64", |b| {
+            let v = ValueBag::from_fill(&|slot: value_bag::fill::Slot| slot.fill_sval2(&1u8));
+
+            b.iter(|| black_box(v.to_u64()))
+        });
+    }
 }
 
-#[bench]
-fn u8_capture_from_to_u64(b: &mut test::Bencher) {
-    let v = ValueBag::from(1u8);
-    b.iter(|| v.to_u64())
-}
-
-#[bench]
-fn u8_capture_debug_to_u64(b: &mut test::Bencher) {
-    let v = ValueBag::capture_debug(&1u8);
-    b.iter(|| v.to_u64())
-}
-
-#[bench]
-fn u8_fill_to_u64(b: &mut test::Bencher) {
-    let v = ValueBag::from_fill(&|slot: value_bag::fill::Slot| slot.fill_any(1u8));
-
-    b.iter(|| v.to_u64())
-}
-
-#[bench]
-#[cfg(feature = "sval2")]
-fn u8_from_sval_to_u64(b: &mut test::Bencher) {
-    let v = ValueBag::from_sval2(&1u8);
-
-    b.iter(|| v.to_u64())
-}
-
-#[bench]
-#[cfg(feature = "sval2")]
-fn u8_fill_sval_to_u64(b: &mut test::Bencher) {
-    let v = ValueBag::from_fill(&|slot: value_bag::fill::Slot| slot.fill_sval2(&1u8));
-
-    b.iter(|| v.to_u64())
-}
-
-#[bench]
-fn u8_capture_debug_to_borrowed_str(b: &mut test::Bencher) {
-    let v = ValueBag::capture_debug(&1u8);
-    b.iter(|| v.to_borrowed_str())
-}
-
-#[bench]
-fn str_capture_debug_to_borrowed_str(b: &mut test::Bencher) {
-    let v = ValueBag::capture_debug(&"a string");
-    b.iter(|| v.to_borrowed_str())
-}
-
-#[bench]
-fn str_capture_debug_to_u64(b: &mut test::Bencher) {
-    let v = ValueBag::capture_debug(&"a string");
-    b.iter(|| v.to_u64())
-}
-
-#[bench]
-fn custom_capture_debug_to_str(b: &mut test::Bencher) {
-    #[derive(Debug)]
-    struct A;
-
-    let v = ValueBag::capture_debug(&A);
-    b.iter(|| v.to_borrowed_str())
-}
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/owned.rs
+++ b/benches/owned.rs
@@ -1,111 +1,121 @@
-#![cfg(feature = "owned")]
-#![feature(test)]
+#[cfg(feature = "owned")]
+mod imp {
+    use value_bag::ValueBag;
 
-extern crate test;
+    use criterion::{criterion_group, criterion_main, Criterion};
+    use std::hint::black_box;
 
-use value_bag::ValueBag;
+    pub fn criterion_benchmark(c: &mut Criterion) {
+        c.bench_function("from u8 to owned", |b| {
+            let v = ValueBag::from(1u8);
 
-#[bench]
-fn u8_to_owned(b: &mut test::Bencher) {
-    let bag = ValueBag::from(1u8);
+            b.iter(|| black_box(v.to_owned()))
+        });
 
-    b.iter(|| bag.to_owned());
-}
+        c.bench_function("from str to owned", |b| {
+            let v = ValueBag::from("a string");
 
-#[bench]
-fn str_to_owned(b: &mut test::Bencher) {
-    let bag = ValueBag::from("a string");
+            b.iter(|| black_box(v.to_owned()))
+        });
 
-    b.iter(|| bag.to_owned());
-}
+        c.bench_function("from str owned clone", |b| {
+            let v = ValueBag::from("a string").to_owned();
 
-#[bench]
-fn str_to_owned_clone(b: &mut test::Bencher) {
-    let bag = ValueBag::from("a string").to_owned();
+            b.iter(|| black_box(v.clone()))
+        });
 
-    b.iter(|| bag.clone());
-}
+        c.bench_function("from str to shared", |b| {
+            let v = ValueBag::from("a string");
 
-#[bench]
-fn str_to_shared(b: &mut test::Bencher) {
-    let bag = ValueBag::from("a string");
+            b.iter(|| black_box(v.to_shared()))
+        });
 
-    b.iter(|| bag.to_shared());
-}
+        c.bench_function("from str shared clone", |b| {
+            let v = ValueBag::from("a string").to_shared();
 
-#[bench]
-fn str_to_shared_clone(b: &mut test::Bencher) {
-    let bag = ValueBag::from("a string").to_shared();
+            b.iter(|| black_box(v.clone()))
+        });
 
-    b.iter(|| bag.clone());
-}
+        c.bench_function("from display to owned", |b| {
+            let v = ValueBag::from_display(&42);
 
-#[bench]
-fn display_to_owned(b: &mut test::Bencher) {
-    let bag = ValueBag::from_display(&42);
+            b.iter(|| black_box(v.to_owned()))
+        });
 
-    b.iter(|| bag.to_owned());
-}
+        #[cfg(feature = "serde1")]
+        {
+            c.bench_function("from serde to owned", |b| {
+                use value_bag_serde1::lib::ser::{Serialize, SerializeStruct, Serializer};
 
-#[cfg(feature = "serde1")]
-#[bench]
-fn serde1_to_owned(b: &mut test::Bencher) {
-    use value_bag_serde1::lib::ser::{Serialize, SerializeStruct, Serializer};
+                pub struct MyData<'a> {
+                    a: i32,
+                    b: &'a str,
+                }
 
-    pub struct MyData<'a> {
-        a: i32,
-        b: &'a str,
-    }
+                impl<'a> Serialize for MyData<'a> {
+                    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                        let mut serializer = serializer.serialize_struct("MyData", 2)?;
 
-    impl<'a> Serialize for MyData<'a> {
-        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-            let mut serializer = serializer.serialize_struct("MyData", 2)?;
+                        serializer.serialize_field("a", &self.a)?;
+                        serializer.serialize_field("b", &self.b)?;
 
-            serializer.serialize_field("a", &self.a)?;
-            serializer.serialize_field("b", &self.b)?;
+                        serializer.end()
+                    }
+                }
 
-            serializer.end()
+                let v = ValueBag::from_serde1(&MyData {
+                    a: 42,
+                    b: "a string",
+                });
+
+                b.iter(|| black_box(v.to_owned()))
+            });
+        }
+
+        #[cfg(feature = "sval2")]
+        {
+            c.bench_function("from sval to owned", |b| {
+                use value_bag_sval2::lib::{Label, Result, Stream, Value};
+
+                pub struct MyData<'a> {
+                    a: i32,
+                    b: &'a str,
+                }
+
+                impl<'a> Value for MyData<'a> {
+                    fn stream<'sval, S: Stream<'sval> + ?Sized>(
+                        &'sval self,
+                        stream: &mut S,
+                    ) -> Result {
+                        stream.record_begin(None, Some(&Label::new("MyData")), None, Some(2))?;
+
+                        stream.record_value_begin(None, &Label::new("a"))?;
+                        stream.value(&self.a)?;
+                        stream.record_value_end(None, &Label::new("a"))?;
+
+                        stream.record_value_begin(None, &Label::new("b"))?;
+                        stream.value(&self.b)?;
+                        stream.record_value_end(None, &Label::new("b"))?;
+
+                        stream.record_end(None, Some(&Label::new("MyData")), None)
+                    }
+                }
+
+                let v = ValueBag::from_sval2(&MyData {
+                    a: 42,
+                    b: "a string",
+                });
+
+                b.iter(|| black_box(v.to_owned()))
+            });
         }
     }
-
-    let bag = ValueBag::from_serde1(&MyData {
-        a: 42,
-        b: "a string",
-    });
-
-    b.iter(|| bag.to_owned());
 }
 
-#[cfg(feature = "sval2")]
-#[bench]
-fn sval2_to_owned(b: &mut test::Bencher) {
-    use value_bag_sval2::lib::{Label, Result, Stream, Value};
+#[cfg(feature = "owned")]
+criterion_group!(benches, imp::criterion_benchmark);
+#[cfg(feature = "owned")]
+criterion_main!(benches);
 
-    pub struct MyData<'a> {
-        a: i32,
-        b: &'a str,
-    }
-
-    impl<'a> Value for MyData<'a> {
-        fn stream<'sval, S: Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> Result {
-            stream.record_begin(None, Some(&Label::new("MyData")), None, Some(2))?;
-
-            stream.record_value_begin(None, &Label::new("a"))?;
-            stream.value(&self.a)?;
-            stream.record_value_end(None, &Label::new("a"))?;
-
-            stream.record_value_begin(None, &Label::new("b"))?;
-            stream.value(&self.b)?;
-            stream.record_value_end(None, &Label::new("b"))?;
-
-            stream.record_end(None, Some(&Label::new("MyData")), None)
-        }
-    }
-
-    let bag = ValueBag::from_sval2(&MyData {
-        a: 42,
-        b: "a string",
-    });
-
-    b.iter(|| bag.to_owned());
-}
+#[cfg(not(feature = "owned"))]
+fn main() {}

--- a/benches/seq.rs
+++ b/benches/seq.rs
@@ -1,22 +1,35 @@
-#![cfg(feature = "seq")]
-#![feature(test)]
+#[cfg(feature = "seq")]
+mod imp {
+    use value_bag::ValueBag;
 
-extern crate test;
+    use criterion::{criterion_group, criterion_main, Criterion};
+    use std::hint::black_box;
 
-use value_bag::ValueBag;
+    pub fn criterion_benchmark(c: &mut Criterion) {
+        #[cfg(feature = "serde1")]
+        {
+            c.bench_function("from serde to f64 seq 5", |b| {
+                let v = ValueBag::from_serde1(&[1.0, 2.0, 3.0, 4.0, 5.0]);
 
-#[cfg(feature = "serde1")]
-#[bench]
-fn serde1_to_seq_5(b: &mut test::Bencher) {
-    let v = ValueBag::from_serde1(&[1.0, 2.0, 3.0, 4.0, 5.0]);
+                b.iter(|| black_box(v.to_f64_seq::<Vec<Option<f64>>>()))
+            });
+        }
 
-    b.iter(|| v.to_f64_seq::<Vec<Option<f64>>>())
+        #[cfg(feature = "sval2")]
+        {
+            c.bench_function("from sval to f64 seq 5", |b| {
+                let v = ValueBag::from_sval2(&[1.0, 2.0, 3.0, 4.0, 5.0]);
+
+                b.iter(|| black_box(v.to_f64_seq::<Vec<Option<f64>>>()))
+            });
+        }
+    }
 }
 
-#[cfg(feature = "sval2")]
-#[bench]
-fn sval2_to_seq_5(b: &mut test::Bencher) {
-    let v = ValueBag::from_sval2(&[1.0, 2.0, 3.0, 4.0, 5.0]);
+#[cfg(feature = "seq")]
+criterion_group!(benches, imp::criterion_benchmark);
+#[cfg(feature = "seq")]
+criterion_main!(benches);
 
-    b.iter(|| v.to_f64_seq::<Vec<Option<f64>>>())
-}
+#[cfg(not(feature = "seq"))]
+fn main() {}

--- a/src/internal/seq.rs
+++ b/src/internal/seq.rs
@@ -174,6 +174,16 @@ impl<'s, 'f> Slot<'s, 'f> {
     {
         self.fill(|visitor| visitor.seq(SeqSlice::new_ref(value)))
     }
+
+    /// Fill the slot with a sequence of values that aren't known upfront.
+    ///
+    /// The given elements don't need to satisfy any particulra lifetime constraints.
+    pub fn fill_seq_for_each(
+        self,
+        for_each: impl FnMut(SeqSlot) -> ControlFlow<()>,
+    ) -> Result<(), Error> {
+        todo!()
+    }
 }
 
 /*

--- a/src/internal/seq.rs
+++ b/src/internal/seq.rs
@@ -174,16 +174,6 @@ impl<'s, 'f> Slot<'s, 'f> {
     {
         self.fill(|visitor| visitor.seq(SeqSlice::new_ref(value)))
     }
-
-    /// Fill the slot with a sequence of values that aren't known upfront.
-    ///
-    /// The given elements don't need to satisfy any particulra lifetime constraints.
-    pub fn fill_seq_for_each(
-        self,
-        for_each: impl FnMut(SeqSlot) -> ControlFlow<()>,
-    ) -> Result<(), Error> {
-        todo!()
-    }
 }
 
 /*


### PR DESCRIPTION
This PR just ports our existing benches to `criterion`. They aren't exactly high quality benches, but give a useful indication of the overhead imposed by `ValueBag`.