### PR TITLE
Store small Debug/Display types inline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,12 @@ members = [
 # Store 128bit numbers inline instead of as references
 # This may increase the size of `ValueBag` on some platforms
 inline-i128 = []
-# Store small strings inline instead of as references
+# Store up to 22 byte strings inline instead of boxing in `OwnedValueBag`
 # This requires a more recent Rust toolchain
 inline-str = []
+# Store up to 46 byte strings inline instead of boxing in `OwnedValueBag`
+# This requires a more recent Rust toolchain
+inline-str-l = ["inline-str"]
 
 # Use the standard library
 std = [

--- a/benches/capture.rs
+++ b/benches/capture.rs
@@ -1,9 +1,8 @@
 use value_bag::ValueBag;
 
-use criterion::{criterion_group, criterion_main, Criterion};
 use std::hint::black_box;
 
-fn criterion_benchmark(c: &mut Criterion) {
+fn criterion_benchmark(c: &mut criterion::Criterion) {
     c.bench_function("capture u8 from", |b| {
         b.iter(|| black_box(ValueBag::from(1u8)))
     });
@@ -92,5 +91,5 @@ fn criterion_benchmark(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, criterion_benchmark);
-criterion_main!(benches);
+criterion::criterion_group!(benches, criterion_benchmark);
+criterion::criterion_main!(benches);

--- a/benches/owned.rs
+++ b/benches/owned.rs
@@ -2,7 +2,16 @@
 mod imp {
     use value_bag::ValueBag;
 
-    use std::hint::black_box;
+    use std::{fmt, hint::black_box};
+
+    // Clobber `ToString` specialization for `&str`
+    struct Display(&'static str);
+
+    impl fmt::Display for Display {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str(self.0)
+        }
+    }
 
     pub fn criterion_benchmark(c: &mut criterion::Criterion) {
         c.bench_function("from u8 to owned", |b| {
@@ -35,8 +44,20 @@ mod imp {
             b.iter(|| black_box(v.clone()))
         });
 
-        c.bench_function("from display to owned", |b| {
-            let v = ValueBag::from_display(&42);
+        c.bench_function("from display to owned 2b", |b| {
+            let v = ValueBag::from_display(&Display("42"));
+
+            b.iter(|| black_box(v.to_owned()))
+        });
+
+        c.bench_function("from display to owned 32b", |b| {
+            let v = ValueBag::from_display(&Display("4bf92f3577b34da6a3ce929d0e0e4736"));
+
+            b.iter(|| black_box(v.to_owned()))
+        });
+
+        c.bench_function("from display to owned 36b", |b| {
+            let v = ValueBag::from_display(&Display("8be4df61-93ca-11d2-aa0d-00e098032b8c"));
 
             b.iter(|| black_box(v.to_owned()))
         });

--- a/benches/owned.rs
+++ b/benches/owned.rs
@@ -2,10 +2,9 @@
 mod imp {
     use value_bag::ValueBag;
 
-    use criterion::{criterion_group, criterion_main, Criterion};
     use std::hint::black_box;
 
-    pub fn criterion_benchmark(c: &mut Criterion) {
+    pub fn criterion_benchmark(c: &mut criterion::Criterion) {
         c.bench_function("from u8 to owned", |b| {
             let v = ValueBag::from(1u8);
 
@@ -113,9 +112,9 @@ mod imp {
 }
 
 #[cfg(feature = "owned")]
-criterion_group!(benches, imp::criterion_benchmark);
+criterion::criterion_group!(benches, imp::criterion_benchmark);
 #[cfg(feature = "owned")]
-criterion_main!(benches);
+criterion::criterion_main!(benches);
 
 #[cfg(not(feature = "owned"))]
 fn main() {}

--- a/benches/seq.rs
+++ b/benches/seq.rs
@@ -2,10 +2,9 @@
 mod imp {
     use value_bag::ValueBag;
 
-    use criterion::{criterion_group, criterion_main, Criterion};
     use std::hint::black_box;
 
-    pub fn criterion_benchmark(c: &mut Criterion) {
+    pub fn criterion_benchmark(c: &mut criterion::Criterion) {
         #[cfg(feature = "serde1")]
         {
             c.bench_function("from serde to f64 seq 5", |b| {
@@ -27,9 +26,9 @@ mod imp {
 }
 
 #[cfg(feature = "seq")]
-criterion_group!(benches, imp::criterion_benchmark);
+criterion::criterion_group!(benches, imp::criterion_benchmark);
 #[cfg(feature = "seq")]
-criterion_main!(benches);
+criterion::criterion_main!(benches);
 
 #[cfg(not(feature = "seq"))]
 fn main() {}

--- a/src/internal/fmt.rs
+++ b/src/internal/fmt.rs
@@ -390,7 +390,10 @@ mod seq {
 
 #[cfg(feature = "owned")]
 pub(crate) mod owned {
-    use crate::std::{boxed::Box, fmt, string::ToString};
+    use crate::std::{boxed::Box, fmt};
+
+    #[cfg(feature = "inline-str")]
+    use crate::internal::owned::inline_str::{self, InlineStr};
 
     impl fmt::Debug for crate::OwnedValueBag {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -404,15 +407,32 @@ pub(crate) mod owned {
         }
     }
 
+    #[cfg(not(feature = "inline-str"))]
+    pub(crate) enum InlineFmt {}
+
     #[derive(Clone)]
     pub(crate) struct OwnedFmt(Box<str>);
 
-    pub(crate) fn buffer_debug(v: impl fmt::Debug) -> OwnedFmt {
-        OwnedFmt(format!("{:?}", v).into())
+    pub(crate) fn buffer_debug(v: impl fmt::Debug) -> Result<InlineFmt, OwnedFmt> {
+        #[cfg(feature = "inline-str")]
+        {
+            buffer_inline(format_args!("{v:?}"))
+        }
+        #[cfg(not(feature = "inline-str"))]
+        {
+            Err(OwnedFmt(format!("{v:?}").into()))
+        }
     }
 
-    pub(crate) fn buffer_display(v: impl fmt::Display) -> OwnedFmt {
-        OwnedFmt(v.to_string().into())
+    pub(crate) fn buffer_display(v: impl fmt::Display) -> Result<InlineFmt, OwnedFmt> {
+        #[cfg(feature = "inline-str")]
+        {
+            buffer_inline(v)
+        }
+        #[cfg(not(feature = "inline-str"))]
+        {
+            Err(OwnedFmt(v.to_string().into()))
+        }
     }
 
     impl fmt::Debug for OwnedFmt {
@@ -422,6 +442,41 @@ pub(crate) mod owned {
     }
 
     impl fmt::Display for OwnedFmt {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fmt::Display::fmt(&self.0, f)
+        }
+    }
+
+    #[cfg(feature = "inline-str")]
+    #[inline]
+    fn buffer_inline(v: impl fmt::Display) -> Result<InlineFmt, OwnedFmt> {
+        // Use a slightly larger buffer in case we can compress the resulting buffer down to 22 bytes
+        match InlineStr::<64>::buffer(v) {
+            Ok(inline) => {
+                // TODO: Detect a few common cases and compress them; 32byte hex etc
+                if inline.get().len() <= inline_str::MAX_INLINE_LEN {
+                    Ok(InlineFmt(InlineStr::copy_from(inline.get())))
+                } else {
+                    Err(OwnedFmt(Box::from(inline.get())))
+                }
+            }
+            Err(spilled) => Err(OwnedFmt(spilled)),
+        }
+    }
+
+    #[cfg(feature = "inline-str")]
+    #[derive(Clone, Copy)]
+    pub(crate) struct InlineFmt(InlineStr<{ inline_str::MAX_INLINE_LEN }>);
+
+    #[cfg(feature = "inline-str")]
+    impl fmt::Debug for InlineFmt {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fmt::Display::fmt(self, f)
+        }
+    }
+
+    #[cfg(feature = "inline-str")]
+    impl fmt::Display for InlineFmt {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             fmt::Display::fmt(&self.0, f)
         }

--- a/src/internal/fmt.rs
+++ b/src/internal/fmt.rs
@@ -431,6 +431,8 @@ pub(crate) mod owned {
         }
         #[cfg(not(feature = "inline-str"))]
         {
+            use crate::std::string::ToString as _;
+
             Err(OwnedFmt(v.to_string().into()))
         }
     }
@@ -453,9 +455,15 @@ pub(crate) mod owned {
         // Use a slightly larger buffer in case we can compress the resulting buffer down to 22 bytes
         match InlineStr::<64>::buffer(v) {
             Ok(inline) => {
-                // TODO: Detect a few common cases and compress them; 32byte hex etc
-                if inline.get().len() <= inline_str::MAX_INLINE_LEN {
-                    Ok(InlineFmt(InlineStr::copy_from(inline.get())))
+                if inline.len() <= inline_str::MAX_INLINE_LEN {
+                    // SAFETY: The condition above guarantees `inline` will fit in `MAX_INLINE_LEN` bytes
+                    let inline = unsafe {
+                        InlineStr::<{ inline_str::MAX_INLINE_LEN }>::copy_from_unchecked(
+                            inline.get(),
+                        )
+                    };
+
+                    Ok(InlineFmt(inline))
                 } else {
                     Err(OwnedFmt(Box::from(inline.get())))
                 }

--- a/src/internal/fmt.rs
+++ b/src/internal/fmt.rs
@@ -453,6 +453,7 @@ pub(crate) mod owned {
     #[inline]
     fn buffer_inline(v: impl fmt::Display) -> Result<InlineFmt, OwnedFmt> {
         // Use a slightly larger buffer in case we can compress the resulting buffer down to 22 bytes
+        // This can also save a few extra bounds checks and re-allocations
         match InlineStr::<64>::buffer(v) {
             Ok(inline) => {
                 if inline.len() <= inline_str::MAX_INLINE_LEN {

--- a/src/internal/owned.rs
+++ b/src/internal/owned.rs
@@ -13,12 +13,16 @@ pub(crate) enum OwnedInternal {
     Bool(bool),
     Char(char),
     #[cfg(feature = "inline-str")]
-    StrSmall(inline_str::InlineStr),
+    StrSmall(inline_str::InlineStr<{ inline_str::MAX_INLINE_LEN }>),
     Str(Box<str>),
     None,
 
     // Buffered values
+    #[cfg(feature = "inline-str")]
+    DebugSmall(internal::fmt::owned::InlineFmt),
     Debug(internal::fmt::owned::OwnedFmt),
+    #[cfg(feature = "inline-str")]
+    DisplaySmall(internal::fmt::owned::InlineFmt),
     Display(internal::fmt::owned::OwnedFmt),
     #[cfg(feature = "error")]
     Error(internal::error::owned::OwnedError),
@@ -66,7 +70,11 @@ impl OwnedInternal {
             OwnedInternal::None => Internal::None,
 
             OwnedInternal::Debug(v) => Internal::AnonDebug(v),
+            #[cfg(feature = "inline-str")]
+            OwnedInternal::DebugSmall(v) => Internal::AnonDebug(v),
             OwnedInternal::Display(v) => Internal::AnonDisplay(v),
+            #[cfg(feature = "inline-str")]
+            OwnedInternal::DisplaySmall(v) => Internal::AnonDisplay(v),
             #[cfg(feature = "error")]
             OwnedInternal::Error(v) => Internal::AnonError(v),
             #[cfg(feature = "serde1")]
@@ -105,7 +113,11 @@ impl OwnedInternal {
             OwnedInternal::None => OwnedInternal::None,
 
             OwnedInternal::Debug(v) => OwnedInternal::SharedDebug(Arc::new(v)),
+            #[cfg(feature = "inline-str")]
+            OwnedInternal::DebugSmall(v) => OwnedInternal::DebugSmall(v),
             OwnedInternal::Display(v) => OwnedInternal::SharedDisplay(Arc::new(v)),
+            #[cfg(feature = "inline-str")]
+            OwnedInternal::DisplaySmall(v) => OwnedInternal::DisplaySmall(v),
             #[cfg(feature = "error")]
             OwnedInternal::Error(v) => OwnedInternal::SharedError(Arc::new(v)),
             #[cfg(feature = "serde1")]
@@ -141,7 +153,13 @@ impl<'v> Internal<'v> {
             }
 
             fn debug(&mut self, v: &dyn internal::fmt::Debug) -> Result<(), Error> {
-                self.0 = OwnedInternal::Debug(internal::fmt::owned::buffer_debug(v));
+                self.0 = match internal::fmt::owned::buffer_debug(v) {
+                    #[cfg(feature = "inline-str")]
+                    Ok(inline) => OwnedInternal::DebugSmall(inline),
+                    #[cfg(not(feature = "inline-str"))]
+                    Ok(_) => unreachable!(),
+                    Err(spilled) => OwnedInternal::Debug(spilled),
+                };
                 Ok(())
             }
 
@@ -154,7 +172,13 @@ impl<'v> Internal<'v> {
             }
 
             fn display(&mut self, v: &dyn internal::fmt::Display) -> Result<(), Error> {
-                self.0 = OwnedInternal::Display(internal::fmt::owned::buffer_display(v));
+                self.0 = match internal::fmt::owned::buffer_display(v) {
+                    #[cfg(feature = "inline-str")]
+                    Ok(inline) => OwnedInternal::DisplaySmall(inline),
+                    #[cfg(not(feature = "inline-str"))]
+                    Ok(_) => unreachable!(),
+                    Err(spilled) => OwnedInternal::Display(spilled),
+                };
                 Ok(())
             }
 
@@ -300,35 +324,41 @@ impl<'v> Internal<'v> {
 }
 
 #[cfg(feature = "inline-str")]
-mod inline_str {
-    use crate::std::{fmt, slice, str};
+pub(crate) mod inline_str {
+    use crate::std::{
+        boxed::Box,
+        fmt::{self, Write as _},
+        slice, str,
+        string::String,
+    };
 
-    pub(super) const MAX_INLINE_LEN: usize = 22;
+    pub(crate) const MAX_INLINE_LEN: usize = 22;
 
     #[derive(Clone, Copy)]
-    pub(crate) struct InlineStr {
-        data: [u8; MAX_INLINE_LEN],
+    pub(crate) struct InlineStr<const MAX_LEN: usize> {
+        data: [u8; MAX_LEN],
         len: u8,
     }
 
-    impl fmt::Debug for InlineStr {
+    impl<const N: usize> fmt::Debug for InlineStr<N> {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             fmt::Debug::fmt(self.get(), f)
         }
     }
 
-    impl fmt::Display for InlineStr {
+    impl<const N: usize> fmt::Display for InlineStr<N> {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             fmt::Display::fmt(self.get(), f)
         }
     }
 
-    impl InlineStr {
-        pub(super) fn copy_from(str: &str) -> Self {
+    impl<const N: usize> InlineStr<N> {
+        #[inline]
+        pub(crate) fn copy_from(str: &str) -> Self {
             let str = str.as_bytes();
 
             // NOTE: This will panic if the string is too big
-            let mut data = [0; MAX_INLINE_LEN];
+            let mut data = [0; N];
             data[..str.len()].copy_from_slice(str);
 
             InlineStr {
@@ -337,7 +367,8 @@ mod inline_str {
             }
         }
 
-        pub(super) const fn get(&self) -> &str {
+        #[inline]
+        pub(crate) const fn get(&self) -> &str {
             // NOTE: We can't slice data in `const` fns yet, so we do it this way
             // SAFETY: `data` contains valid UTF8, and `len` points within `data`
             unsafe {
@@ -345,6 +376,53 @@ mod inline_str {
                     &self.data as *const u8,
                     self.len as usize,
                 ))
+            }
+        }
+
+        pub(crate) fn buffer(v: impl fmt::Display) -> Result<Self, Box<str>> {
+            // Attempt to format a `fmt::Display` into a stack-allocated buffer
+            struct Buffer<const N: usize> {
+                inline: [u8; N],
+                spilled: String,
+                len: usize,
+            }
+
+            impl<const N: usize> fmt::Write for Buffer<N> {
+                fn write_str(&mut self, v: &str) -> fmt::Result {
+                    if self.len + v.len() > N {
+                        // Spill
+                        if self.spilled.len() == 0 {
+                            self.spilled.push_str(unsafe {
+                                str::from_utf8_unchecked(&self.inline[..self.len])
+                            });
+                        }
+
+                        self.spilled.push_str(v);
+                    } else {
+                        self.inline[self.len..self.len + v.len()].copy_from_slice(v.as_bytes());
+                    }
+
+                    self.len += v.len();
+
+                    Ok(())
+                }
+            }
+
+            let mut buffer = Buffer {
+                inline: [0; N],
+                spilled: String::new(),
+                len: 0,
+            };
+
+            let _ = write!(&mut buffer, "{v}");
+
+            if buffer.len <= N {
+                Ok(InlineStr {
+                    data: buffer.inline,
+                    len: buffer.len as u8,
+                })
+            } else {
+                Err(buffer.spilled.into_boxed_str())
             }
         }
     }
@@ -357,7 +435,7 @@ mod inline_str {
 
         #[test]
         fn inline_str() {
-            let s = InlineStr::copy_from("abc");
+            let s = InlineStr::<22>::copy_from("abc");
 
             assert_eq!("abc", s.get());
             assert_eq!("abc", s.to_string());

--- a/src/internal/owned.rs
+++ b/src/internal/owned.rs
@@ -13,16 +13,16 @@ pub(crate) enum OwnedInternal {
     Bool(bool),
     Char(char),
     #[cfg(feature = "inline-str")]
-    StrSmall(inline_str::InlineStr<{ inline_str::MAX_INLINE_LEN }>),
+    SmallStr(inline_str::InlineStr<{ inline_str::MAX_INLINE_LEN }>),
     Str(Box<str>),
     None,
 
     // Buffered values
     #[cfg(feature = "inline-str")]
-    DebugSmall(internal::fmt::owned::InlineFmt),
+    SmallDebug(internal::fmt::owned::InlineFmt),
     Debug(internal::fmt::owned::OwnedFmt),
     #[cfg(feature = "inline-str")]
-    DisplaySmall(internal::fmt::owned::InlineFmt),
+    SmallDisplay(internal::fmt::owned::InlineFmt),
     Display(internal::fmt::owned::OwnedFmt),
     #[cfg(feature = "error")]
     Error(internal::error::owned::OwnedError),
@@ -66,15 +66,15 @@ impl OwnedInternal {
             OwnedInternal::Char(v) => Internal::Char(*v),
             OwnedInternal::Str(v) => Internal::Str(v),
             #[cfg(feature = "inline-str")]
-            OwnedInternal::StrSmall(v) => Internal::Str(v.get()),
+            OwnedInternal::SmallStr(v) => Internal::Str(v.get()),
             OwnedInternal::None => Internal::None,
 
             OwnedInternal::Debug(v) => Internal::AnonDebug(v),
             #[cfg(feature = "inline-str")]
-            OwnedInternal::DebugSmall(v) => Internal::AnonDebug(v),
+            OwnedInternal::SmallDebug(v) => Internal::AnonDebug(v),
             OwnedInternal::Display(v) => Internal::AnonDisplay(v),
             #[cfg(feature = "inline-str")]
-            OwnedInternal::DisplaySmall(v) => Internal::AnonDisplay(v),
+            OwnedInternal::SmallDisplay(v) => Internal::AnonDisplay(v),
             #[cfg(feature = "error")]
             OwnedInternal::Error(v) => Internal::AnonError(v),
             #[cfg(feature = "serde1")]
@@ -109,15 +109,15 @@ impl OwnedInternal {
             OwnedInternal::Char(v) => OwnedInternal::Char(v),
             OwnedInternal::Str(v) => OwnedInternal::Str(v),
             #[cfg(feature = "inline-str")]
-            OwnedInternal::StrSmall(v) => OwnedInternal::StrSmall(v),
+            OwnedInternal::SmallStr(v) => OwnedInternal::SmallStr(v),
             OwnedInternal::None => OwnedInternal::None,
 
             OwnedInternal::Debug(v) => OwnedInternal::SharedDebug(Arc::new(v)),
             #[cfg(feature = "inline-str")]
-            OwnedInternal::DebugSmall(v) => OwnedInternal::DebugSmall(v),
+            OwnedInternal::SmallDebug(v) => OwnedInternal::SmallDebug(v),
             OwnedInternal::Display(v) => OwnedInternal::SharedDisplay(Arc::new(v)),
             #[cfg(feature = "inline-str")]
-            OwnedInternal::DisplaySmall(v) => OwnedInternal::DisplaySmall(v),
+            OwnedInternal::SmallDisplay(v) => OwnedInternal::SmallDisplay(v),
             #[cfg(feature = "error")]
             OwnedInternal::Error(v) => OwnedInternal::SharedError(Arc::new(v)),
             #[cfg(feature = "serde1")]
@@ -155,7 +155,7 @@ impl<'v> Internal<'v> {
             fn debug(&mut self, v: &dyn internal::fmt::Debug) -> Result<(), Error> {
                 self.0 = match internal::fmt::owned::buffer_debug(v) {
                     #[cfg(feature = "inline-str")]
-                    Ok(inline) => OwnedInternal::DebugSmall(inline),
+                    Ok(inline) => OwnedInternal::SmallDebug(inline),
                     #[cfg(not(feature = "inline-str"))]
                     Ok(_) => unreachable!(),
                     Err(spilled) => OwnedInternal::Debug(spilled),
@@ -174,7 +174,7 @@ impl<'v> Internal<'v> {
             fn display(&mut self, v: &dyn internal::fmt::Display) -> Result<(), Error> {
                 self.0 = match internal::fmt::owned::buffer_display(v) {
                     #[cfg(feature = "inline-str")]
-                    Ok(inline) => OwnedInternal::DisplaySmall(inline),
+                    Ok(inline) => OwnedInternal::SmallDisplay(inline),
                     #[cfg(not(feature = "inline-str"))]
                     Ok(_) => unreachable!(),
                     Err(spilled) => OwnedInternal::Display(spilled),
@@ -229,7 +229,7 @@ impl<'v> Internal<'v> {
                 #[cfg(feature = "inline-str")]
                 {
                     if v.len() <= inline_str::MAX_INLINE_LEN {
-                        self.0 = OwnedInternal::StrSmall(inline_str::InlineStr::copy_from(v));
+                        self.0 = OwnedInternal::SmallStr(inline_str::InlineStr::copy_from(v));
                         return Ok(());
                     }
                 }
@@ -332,7 +332,10 @@ pub(crate) mod inline_str {
         string::String,
     };
 
+    #[cfg(not(feature = "inline-str-l"))]
     pub(crate) const MAX_INLINE_LEN: usize = 22;
+    #[cfg(feature = "inline-str-l")]
+    pub(crate) const MAX_INLINE_LEN: usize = 46;
 
     #[derive(Clone, Copy)]
     pub(crate) struct InlineStr<const MAX_LEN: usize> {
@@ -355,16 +358,37 @@ pub(crate) mod inline_str {
     impl<const N: usize> InlineStr<N> {
         #[inline]
         pub(crate) fn copy_from(str: &str) -> Self {
+            assert!(
+                str.len() <= N,
+                "input of {} bytes would overflow max len of {N}",
+                str.len()
+            );
+
+            // SAFETY: The assertion above guarantees `str` will fit in a buffer of `N` bytes
+            unsafe { Self::copy_from_unchecked(str) }
+        }
+
+        #[inline]
+        // SAFETY: Callers must ensure `str.len() <= N`
+        pub(crate) unsafe fn copy_from_unchecked(str: &str) -> Self {
             let str = str.as_bytes();
 
-            // NOTE: This will panic if the string is too big
             let mut data = [0; N];
-            data[..str.len()].copy_from_slice(str);
+
+            // SAFETY: Callers responsible for ensuring `str.len() <= N`
+            unsafe {
+                crate::std::ptr::copy_nonoverlapping(str.as_ptr(), data.as_mut_ptr(), str.len());
+            }
 
             InlineStr {
                 data,
                 len: str.len() as u8,
             }
+        }
+
+        #[inline]
+        pub(crate) const fn len(&self) -> usize {
+            self.len as usize
         }
 
         #[inline]
@@ -379,6 +403,7 @@ pub(crate) mod inline_str {
             }
         }
 
+        #[inline]
         pub(crate) fn buffer(v: impl fmt::Display) -> Result<Self, Box<str>> {
             // Attempt to format a `fmt::Display` into a stack-allocated buffer
             struct Buffer<const N: usize> {
@@ -388,6 +413,7 @@ pub(crate) mod inline_str {
             }
 
             impl<const N: usize> fmt::Write for Buffer<N> {
+                #[inline]
                 fn write_str(&mut self, v: &str) -> fmt::Result {
                     if self.len + v.len() > N {
                         // Spill
@@ -399,7 +425,14 @@ pub(crate) mod inline_str {
 
                         self.spilled.push_str(v);
                     } else {
-                        self.inline[self.len..self.len + v.len()].copy_from_slice(v.as_bytes());
+                        // SAFETY: The bounds check above guarantees `v` can be copied into `self.inline`
+                        unsafe {
+                            crate::std::ptr::copy_nonoverlapping(
+                                v.as_ptr(),
+                                self.inline.as_mut_ptr().add(self.len),
+                                v.len(),
+                            );
+                        }
                     }
 
                     self.len += v.len();
@@ -414,6 +447,7 @@ pub(crate) mod inline_str {
                 len: 0,
             };
 
+            // TODO: Encode alternative if `v` panics, see `serde_fmt`
             let _ = write!(&mut buffer, "{v}");
 
             if buffer.len <= N {

--- a/src/internal/owned.rs
+++ b/src/internal/owned.rs
@@ -371,6 +371,8 @@ pub(crate) mod inline_str {
         #[inline]
         // SAFETY: Callers must ensure `str.len() <= N`
         pub(crate) unsafe fn copy_from_unchecked(str: &str) -> Self {
+            debug_assert!(N > 0);
+
             let str = str.as_bytes();
 
             let mut data = [0; N];
@@ -405,6 +407,8 @@ pub(crate) mod inline_str {
 
         #[inline]
         pub(crate) fn buffer(v: impl fmt::Display) -> Result<Self, Box<str>> {
+            debug_assert!(N > 0);
+
             // Attempt to format a `fmt::Display` into a stack-allocated buffer
             struct Buffer<const N: usize> {
                 inline: [u8; N],
@@ -447,16 +451,20 @@ pub(crate) mod inline_str {
                 len: 0,
             };
 
-            // TODO: Encode alternative if `v` panics, see `serde_fmt`
-            let _ = write!(&mut buffer, "{v}");
-
-            if buffer.len <= N {
-                Ok(InlineStr {
-                    data: buffer.inline,
-                    len: buffer.len as u8,
-                })
-            } else {
-                Err(buffer.spilled.into_boxed_str())
+            // NOTE: Future versions of Rust may give us a more direct way to buffer a `Display`
+            // without needing to go through `Arguments`
+            match write!(&mut buffer, "{v}") {
+                Ok(()) => {
+                    if buffer.len <= N {
+                        Ok(InlineStr {
+                            data: buffer.inline,
+                            len: buffer.len as u8,
+                        })
+                    } else {
+                        Err(buffer.spilled.into_boxed_str())
+                    }
+                }
+                Err(err) => Err(format!("<{err}>").into_boxed_str()),
             }
         }
     }
@@ -473,6 +481,32 @@ pub(crate) mod inline_str {
 
             assert_eq!("abc", s.get());
             assert_eq!("abc", s.to_string());
+        }
+
+        #[test]
+        fn inline_str_buffer() {
+            let s = InlineStr::<3>::buffer("a").unwrap();
+
+            assert_eq!("a", s.get());
+
+            let s = InlineStr::<3>::buffer("abcd").unwrap_err();
+
+            assert_eq!("abcd", &*s);
+        }
+
+        #[test]
+        fn inline_str_buffer_err() {
+            struct FailingDisplay;
+
+            impl fmt::Display for FailingDisplay {
+                fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
+                    Err(fmt::Error)
+                }
+            }
+
+            let s = InlineStr::<22>::buffer(FailingDisplay).unwrap_err();
+
+            assert_eq!("<an error occurred when formatting an argument>", &*s);
         }
     }
 }

--- a/src/owned.rs
+++ b/src/owned.rs
@@ -182,7 +182,10 @@ mod tests {
         std::{mem, string::ToString},
     };
 
+    #[cfg(not(feature = "inline-str-l"))]
     const SIZE_LIMIT_U64: usize = 4;
+    #[cfg(feature = "inline-str-l")]
+    const SIZE_LIMIT_U64: usize = 6;
 
     #[test]
     fn is_send_sync() {
@@ -232,14 +235,28 @@ mod tests {
         let debug = ValueBag::from_debug(&"a value").to_owned();
         let display = ValueBag::from_display(&"a value").to_owned();
 
-        assert!(matches!(
-            debug.inner,
-            internal::owned::OwnedInternal::Debug(_)
-        ));
-        assert!(matches!(
-            display.inner,
-            internal::owned::OwnedInternal::Display(_)
-        ));
+        #[cfg(not(feature = "inline-str"))]
+        {
+            assert!(matches!(
+                debug.inner,
+                internal::owned::OwnedInternal::Debug(_)
+            ));
+            assert!(matches!(
+                display.inner,
+                internal::owned::OwnedInternal::Display(_)
+            ));
+        }
+        #[cfg(feature = "inline-str")]
+        {
+            assert!(matches!(
+                debug.inner,
+                internal::owned::OwnedInternal::SmallDebug(_)
+            ));
+            assert!(matches!(
+                display.inner,
+                internal::owned::OwnedInternal::SmallDisplay(_)
+            ));
+        }
 
         assert_eq!("\"a value\"", debug.to_string());
         assert_eq!("a value", display.to_string());

--- a/src/owned.rs
+++ b/src/owned.rs
@@ -270,18 +270,68 @@ mod tests {
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn fmt_to_owned_l() {
+        let debug =
+            ValueBag::from_debug(&"a value that occupies too much space to ever be stored inline")
+                .to_owned();
+        let display = ValueBag::from_display(
+            &"a value that occupies too much space to ever be stored inline",
+        )
+        .to_owned();
+
+        assert!(matches!(
+            debug.inner,
+            internal::owned::OwnedInternal::Debug(_)
+        ));
+        assert!(matches!(
+            display.inner,
+            internal::owned::OwnedInternal::Display(_)
+        ));
+
+        assert_eq!(
+            "\"a value that occupies too much space to ever be stored inline\"",
+            debug.to_string()
+        );
+        assert_eq!(
+            "a value that occupies too much space to ever be stored inline",
+            display.to_string()
+        );
+
+        let debug = debug.by_ref();
+        let display = display.by_ref();
+
+        assert!(matches!(debug.inner, internal::Internal::AnonDebug(_)));
+        assert!(matches!(display.inner, internal::Internal::AnonDisplay(_)));
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn fmt_to_shared() {
         let debug = ValueBag::from_debug(&"a value").to_shared();
         let display = ValueBag::from_display(&"a value").to_shared();
 
-        assert!(matches!(
-            debug.inner,
-            internal::owned::OwnedInternal::SharedDebug(_)
-        ));
-        assert!(matches!(
-            display.inner,
-            internal::owned::OwnedInternal::SharedDisplay(_)
-        ));
+        #[cfg(not(feature = "inline-str"))]
+        {
+            assert!(matches!(
+                debug.inner,
+                internal::owned::OwnedInternal::SharedDebug(_)
+            ));
+            assert!(matches!(
+                display.inner,
+                internal::owned::OwnedInternal::SharedDisplay(_)
+            ));
+        }
+        #[cfg(feature = "inline-str")]
+        {
+            assert!(matches!(
+                debug.inner,
+                internal::owned::OwnedInternal::SmallDebug(_)
+            ));
+            assert!(matches!(
+                display.inner,
+                internal::owned::OwnedInternal::SmallDisplay(_)
+            ));
+        }
     }
 
     #[test]


### PR DESCRIPTION
This PR improves the performance of buffering small captured `Debug`/`Display` types that aren't primitives. Using the same inline-str infrastructure already used for strings, we'll buffer small values inline instead of unconditionally allocating for them.

We only buffer up to 22 bytes inline, which isn't quite enough for, say, a UUID, so I'd like to also try detect some common patterns and encode them more compactly if we see them. For instance, 32 hex chars can be encoded in 16 bytes, which is under our 22 byte limit. The simplest way to encode this info I think is to use a few of the bits of the length byte on inline strings as a format specifier.