### PR TITLE
Reduce dynamic dispatches when buffering serde and sval

### DIFF
--- a/meta/sval2/Cargo.toml
+++ b/meta/sval2/Cargo.toml
@@ -36,6 +36,10 @@ test = [
     "sval_test",
 ]
 
+owned = [
+    "std",
+]
+
 [dependencies.sval]
 version = "2.1"
 default-features = false

--- a/meta/sval2/Cargo.toml
+++ b/meta/sval2/Cargo.toml
@@ -37,34 +37,34 @@ test = [
 ]
 
 [dependencies.sval]
-version = "2.1"
+version = "2.20"
 default-features = false
 
 [dependencies.sval_ref]
-version = "2.1"
+version = "2.20"
 default-features = false
 
 [dependencies.sval_dynamic]
-version = "2.1"
+version = "2.20"
 default-features = false
 
 [dependencies.sval_buffer]
-version = "2.3"
+version = "2.20"
 default-features = false
 
 [dependencies.sval_fmt]
-version = "2.1"
+version = "2.20"
 default-features = false
 
 [dependencies.sval_serde]
-version = "2.1"
+version = "2.20"
 default-features = false
 optional = true
 
 [dependencies.sval_json]
-version = "2.1"
+version = "2.20"
 optional = true
 
 [dependencies.sval_test]
-version = "2.1"
+version = "2.20"
 optional = true

--- a/meta/sval2/Cargo.toml
+++ b/meta/sval2/Cargo.toml
@@ -36,10 +36,6 @@ test = [
     "sval_test",
 ]
 
-owned = [
-    "std",
-]
-
 [dependencies.sval]
 version = "2.1"
 default-features = false

--- a/meta/sval2/src/lib.rs
+++ b/meta/sval2/src/lib.rs
@@ -2,6 +2,8 @@
 Implementation detail for `value-bag`; it should not be depended on directly.
 */
 
+#![no_std]
+
 pub use sval as lib;
 pub use sval_buffer as buffer;
 pub use sval_dynamic as dynamic;

--- a/meta/sval2/src/lib.rs
+++ b/meta/sval2/src/lib.rs
@@ -2,8 +2,6 @@
 Implementation detail for `value-bag`; it should not be depended on directly.
 */
 
-#![no_std]
-
 pub use sval as lib;
 pub use sval_buffer as buffer;
 pub use sval_dynamic as dynamic;

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -53,8 +53,12 @@ pub(crate) enum Internal<'v> {
     Error(&'v dyn error::DowncastError),
     #[cfg(feature = "sval2")]
     Sval2(&'v dyn sval::v2::DowncastValue),
+    #[cfg(feature = "sval2")]
+    SizedSval2(&'v dyn sval::v2::SizedValue),
     #[cfg(feature = "serde1")]
     Serde1(&'v dyn serde::v1::DowncastSerialize),
+    #[cfg(feature = "serde1")]
+    SizedSerde1(&'v dyn serde::v1::SizedSerialize),
 
     // Anonymous values
     AnonDebug(&'v dyn fmt::Debug),
@@ -169,6 +173,14 @@ pub(crate) trait InternalVisitor<'v> {
     fn borrowed_sval2(&mut self, v: &'v dyn sval::v2::Value) -> Result<(), Error> {
         self.sval2(v)
     }
+    #[cfg(feature = "sval2")]
+    fn borrowed_downcast_sval2(&mut self, v: &'v dyn sval::v2::DowncastValue) -> Result<(), Error> {
+        self.borrowed_sval2(v.as_super())
+    }
+    #[cfg(feature = "sval2")]
+    fn borrowed_sized_sval2(&mut self, v: &'v dyn sval::v2::SizedValue) -> Result<(), Error> {
+        self.borrowed_sval2(v.as_super())
+    }
     #[cfg(all(feature = "sval2", feature = "owned"))]
     fn shared_sval2(
         &mut self,
@@ -182,6 +194,17 @@ pub(crate) trait InternalVisitor<'v> {
     #[cfg(feature = "serde1")]
     fn borrowed_serde1(&mut self, v: &'v dyn serde::v1::Serialize) -> Result<(), Error> {
         self.serde1(v)
+    }
+    #[cfg(feature = "serde1")]
+    fn borrowed_downcast_serde1(
+        &mut self,
+        v: &'v dyn serde::v1::DowncastSerialize,
+    ) -> Result<(), Error> {
+        self.borrowed_serde1(v.as_super())
+    }
+    #[cfg(feature = "serde1")]
+    fn borrowed_sized_serde1(&mut self, v: &'v dyn serde::v1::SizedSerialize) -> Result<(), Error> {
+        self.borrowed_serde1(v.as_super())
     }
     #[cfg(all(feature = "serde1", feature = "owned"))]
     fn shared_serde1(
@@ -319,6 +342,16 @@ impl<'a, 'v, V: InternalVisitor<'v> + ?Sized> InternalVisitor<'v> for &'a mut V 
         (**self).borrowed_sval2(v)
     }
 
+    #[cfg(feature = "sval2")]
+    fn borrowed_downcast_sval2(&mut self, v: &'v dyn sval::v2::DowncastValue) -> Result<(), Error> {
+        (**self).borrowed_downcast_sval2(v)
+    }
+
+    #[cfg(feature = "sval2")]
+    fn borrowed_sized_sval2(&mut self, v: &'v dyn sval::v2::SizedValue) -> Result<(), Error> {
+        (**self).borrowed_sized_sval2(v)
+    }
+
     #[cfg(all(feature = "sval2", feature = "owned"))]
     fn shared_sval2(
         &mut self,
@@ -335,6 +368,19 @@ impl<'a, 'v, V: InternalVisitor<'v> + ?Sized> InternalVisitor<'v> for &'a mut V 
     #[cfg(feature = "serde1")]
     fn borrowed_serde1(&mut self, v: &'v dyn serde::v1::Serialize) -> Result<(), Error> {
         (**self).borrowed_serde1(v)
+    }
+
+    #[cfg(feature = "serde1")]
+    fn borrowed_downcast_serde1(
+        &mut self,
+        v: &'v dyn serde::v1::DowncastSerialize,
+    ) -> Result<(), Error> {
+        (**self).borrowed_downcast_serde1(v)
+    }
+
+    #[cfg(feature = "serde1")]
+    fn borrowed_sized_serde1(&mut self, v: &'v dyn serde::v1::SizedSerialize) -> Result<(), Error> {
+        (**self).borrowed_sized_serde1(v)
     }
 
     #[cfg(all(feature = "serde1", feature = "owned"))]
@@ -403,10 +449,14 @@ impl<'v> Internal<'v> {
             #[cfg(feature = "sval2")]
             Internal::AnonSval2(value) => Internal::AnonSval2(*value),
             #[cfg(feature = "sval2")]
+            Internal::SizedSval2(value) => Internal::SizedSval2(*value),
+            #[cfg(feature = "sval2")]
             Internal::Sval2(value) => Internal::Sval2(*value),
 
             #[cfg(feature = "serde1")]
             Internal::AnonSerde1(value) => Internal::AnonSerde1(*value),
+            #[cfg(feature = "serde1")]
+            Internal::SizedSerde1(value) => Internal::SizedSerde1(*value),
             #[cfg(feature = "serde1")]
             Internal::Serde1(value) => Internal::Serde1(*value),
 
@@ -481,12 +531,16 @@ impl<'v> Internal<'v> {
             #[cfg(feature = "sval2")]
             Internal::AnonSval2(value) => visitor.borrowed_sval2(*value),
             #[cfg(feature = "sval2")]
-            Internal::Sval2(value) => visitor.borrowed_sval2(value.as_super()),
+            Internal::SizedSval2(value) => visitor.borrowed_sized_sval2(*value),
+            #[cfg(feature = "sval2")]
+            Internal::Sval2(value) => visitor.borrowed_downcast_sval2(*value),
 
             #[cfg(feature = "serde1")]
             Internal::AnonSerde1(value) => visitor.borrowed_serde1(*value),
             #[cfg(feature = "serde1")]
-            Internal::Serde1(value) => visitor.borrowed_serde1(value.as_super()),
+            Internal::SizedSerde1(value) => visitor.borrowed_sized_serde1(*value),
+            #[cfg(feature = "serde1")]
+            Internal::Serde1(value) => visitor.borrowed_downcast_serde1(*value),
 
             #[cfg(feature = "seq")]
             Internal::AnonSeq(value) => visitor.borrowed_seq(*value),

--- a/src/internal/owned.rs
+++ b/src/internal/owned.rs
@@ -267,6 +267,40 @@ impl<'v> Internal<'v> {
             }
 
             #[cfg(feature = "sval2")]
+            fn borrowed_sval2(
+                &mut self,
+                v: &'v dyn internal::sval::v2::Value,
+            ) -> Result<(), Error> {
+                self.sval2(v)
+            }
+
+            #[cfg(feature = "sval2")]
+            fn borrowed_downcast_sval2(
+                &mut self,
+                v: &'v dyn internal::sval::v2::DowncastValue,
+            ) -> Result<(), Error> {
+                self.0 = v
+                    .as_buffer()
+                    .buffer()
+                    .map(OwnedInternal::Sval2)
+                    .unwrap_or(OwnedInternal::Poisoned("failed to buffer the value"));
+                Ok(())
+            }
+
+            #[cfg(feature = "sval2")]
+            fn borrowed_sized_sval2(
+                &mut self,
+                v: &'v dyn internal::sval::v2::SizedValue,
+            ) -> Result<(), Error> {
+                self.0 = v
+                    .as_buffer()
+                    .buffer()
+                    .map(OwnedInternal::Sval2)
+                    .unwrap_or(OwnedInternal::Poisoned("failed to buffer the value"));
+                Ok(())
+            }
+
+            #[cfg(feature = "sval2")]
             fn shared_sval2(
                 &mut self,
                 v: &Arc<dyn internal::sval::v2::DowncastValue + Send + Sync>,
@@ -278,6 +312,34 @@ impl<'v> Internal<'v> {
             #[cfg(feature = "serde1")]
             fn serde1(&mut self, v: &dyn internal::serde::v1::Serialize) -> Result<(), Error> {
                 self.0 = internal::serde::v1::owned::buffer(v)
+                    .map(OwnedInternal::Serde1)
+                    .unwrap_or(OwnedInternal::Poisoned("failed to buffer the value"));
+                Ok(())
+            }
+
+            #[cfg(feature = "serde1")]
+            fn borrowed_downcast_serde1(
+                &mut self,
+                v: &'v dyn internal::serde::v1::DowncastSerialize,
+            ) -> Result<(), Error> {
+                self.0 = v
+                    .as_buffer()
+                    .buffer()
+                    .map(Box::new)
+                    .map(OwnedInternal::Serde1)
+                    .unwrap_or(OwnedInternal::Poisoned("failed to buffer the value"));
+                Ok(())
+            }
+
+            #[cfg(feature = "serde1")]
+            fn borrowed_sized_serde1(
+                &mut self,
+                v: &'v dyn internal::serde::v1::SizedSerialize,
+            ) -> Result<(), Error> {
+                self.0 = v
+                    .as_buffer()
+                    .buffer()
+                    .map(Box::new)
                     .map(OwnedInternal::Serde1)
                     .unwrap_or(OwnedInternal::Poisoned("failed to buffer the value"));
                 Ok(())

--- a/src/internal/serde/v1.rs
+++ b/src/internal/serde/v1.rs
@@ -32,7 +32,7 @@ impl<'v> ValueBag<'v> {
         T: value_bag_serde1::lib::Serialize,
     {
         ValueBag {
-            inner: Internal::AnonSerde1(value),
+            inner: Internal::SizedSerde1(value),
         }
     }
 
@@ -47,6 +47,8 @@ impl<'v> ValueBag<'v> {
 pub(crate) trait DowncastSerialize {
     fn as_any(&self) -> &dyn Any;
     fn as_super(&self) -> &dyn Serialize;
+    #[cfg(feature = "owned")]
+    fn as_buffer(&self) -> &dyn BufferSerialize;
 }
 
 impl<T: value_bag_serde1::lib::Serialize + 'static> DowncastSerialize for T {
@@ -56,6 +58,46 @@ impl<T: value_bag_serde1::lib::Serialize + 'static> DowncastSerialize for T {
 
     fn as_super(&self) -> &dyn Serialize {
         self
+    }
+
+    #[cfg(feature = "owned")]
+    fn as_buffer(&self) -> &dyn BufferSerialize {
+        self
+    }
+}
+
+/**
+A value that can be buffered.
+*/
+pub(crate) trait SizedSerialize {
+    fn as_super(&self) -> &dyn Serialize;
+    #[cfg(feature = "owned")]
+    fn as_buffer(&self) -> &dyn BufferSerialize;
+}
+
+impl<T: value_bag_serde1::lib::Serialize> SizedSerialize for T {
+    fn as_super(&self) -> &dyn Serialize {
+        self
+    }
+
+    #[cfg(feature = "owned")]
+    fn as_buffer(&self) -> &dyn BufferSerialize {
+        self
+    }
+}
+
+/**
+A specialization of `Value` that is object safe, but buffers generically to avoid more dynamic dispatch.
+*/
+#[cfg(feature = "owned")]
+pub(crate) trait BufferSerialize {
+    fn buffer(&self) -> Result<value_bag_serde1::buf::Owned, value_bag_serde1::buf::Error>;
+}
+
+#[cfg(feature = "owned")]
+impl<V: value_bag_serde1::lib::Serialize + ?Sized> BufferSerialize for V {
+    fn buffer(&self) -> Result<value_bag_serde1::buf::Owned, value_bag_serde1::buf::Error> {
+        value_bag_serde1::buf::Owned::buffer(self)
     }
 }
 

--- a/src/internal/serde/v1.rs
+++ b/src/internal/serde/v1.rs
@@ -44,6 +44,9 @@ impl<'v> ValueBag<'v> {
     }
 }
 
+/**
+A value that can be downcast and buffered.
+*/
 pub(crate) trait DowncastSerialize {
     fn as_any(&self) -> &dyn Any;
     fn as_super(&self) -> &dyn Serialize;
@@ -87,7 +90,7 @@ impl<T: value_bag_serde1::lib::Serialize> SizedSerialize for T {
 }
 
 /**
-A specialization of `Value` that is object safe, but buffers generically to avoid more dynamic dispatch.
+A specialization of `Serialize` that is object safe, but buffers generically to avoid more dynamic dispatch.
 */
 #[cfg(feature = "owned")]
 pub(crate) trait BufferSerialize {

--- a/src/internal/sval/v2.rs
+++ b/src/internal/sval/v2.rs
@@ -30,7 +30,7 @@ impl<'v> ValueBag<'v> {
         T: value_bag_sval2::lib::Value,
     {
         ValueBag {
-            inner: Internal::AnonSval2(value),
+            inner: Internal::SizedSval2(value),
         }
     }
 
@@ -43,9 +43,13 @@ impl<'v> ValueBag<'v> {
     }
 }
 
+/**
+A value that can be downcast and buffered.
+*/
 pub(crate) trait DowncastValue {
     fn as_any(&self) -> &dyn Any;
     fn as_super(&self) -> &dyn Value;
+    fn as_buffer(&self) -> &dyn BufferValue;
 }
 
 impl<T: value_bag_sval2::lib::Value + 'static> DowncastValue for T {
@@ -55,6 +59,45 @@ impl<T: value_bag_sval2::lib::Value + 'static> DowncastValue for T {
 
     fn as_super(&self) -> &dyn Value {
         self
+    }
+
+    fn as_buffer(&self) -> &dyn BufferValue {
+        self
+    }
+}
+
+/**
+A value that can be buffered.
+*/
+pub(crate) trait SizedValue {
+    fn as_super(&self) -> &dyn Value;
+    fn as_buffer(&self) -> &dyn BufferValue;
+}
+
+impl<T: value_bag_sval2::lib::Value> SizedValue for T {
+    fn as_super(&self) -> &dyn Value {
+        self
+    }
+
+    fn as_buffer(&self) -> &dyn BufferValue {
+        self
+    }
+}
+
+/**
+A specialization of `Value` that is object safe, but buffers generically to avoid more dynamic dispatch.
+*/
+pub(crate) trait BufferValue {
+    fn buffer(
+        &self,
+    ) -> Result<value_bag_sval2::buffer::Value<'static>, value_bag_sval2::buffer::Error>;
+}
+
+impl<V: value_bag_sval2::lib::Value + ?Sized> BufferValue for V {
+    fn buffer(
+        &self,
+    ) -> Result<value_bag_sval2::buffer::Value<'static>, value_bag_sval2::buffer::Error> {
+        value_bag_sval2::buffer::stream_to_value_owned(self).map(|buf| buf.into_value())
     }
 }
 


### PR DESCRIPTION
This PR aims to improve the performance of buffering values by reducing dynamic dispatch machinery involved in `ValueBag::to_owned`. Instead of buffering through the catch-all dyn-traits, which involve dynamic dispatch for each call between the value and serializer, we dynamically dispatch once to a function that's generic over the original value type and the concrete buffering serializer.