### PR TITLE
Avoid extra owned serde boxing

### DIFF
--- a/meta/serde1/Cargo.toml
+++ b/meta/serde1/Cargo.toml
@@ -41,7 +41,7 @@ version = "1"
 default-features = false
 
 [dependencies.serde_buf]
-version = "0.1"
+version = "0.1.3"
 default-features = false
 optional = true
 

--- a/src/internal/owned.rs
+++ b/src/internal/owned.rs
@@ -325,7 +325,6 @@ impl<'v> Internal<'v> {
                 self.0 = v
                     .as_buffer()
                     .buffer()
-                    .map(Box::new)
                     .map(OwnedInternal::Serde1)
                     .unwrap_or(OwnedInternal::Poisoned("failed to buffer the value"));
                 Ok(())
@@ -339,7 +338,6 @@ impl<'v> Internal<'v> {
                 self.0 = v
                     .as_buffer()
                     .buffer()
-                    .map(Box::new)
                     .map(OwnedInternal::Serde1)
                     .unwrap_or(OwnedInternal::Poisoned("failed to buffer the value"));
                 Ok(())

--- a/src/internal/serde/v1.rs
+++ b/src/internal/serde/v1.rs
@@ -764,8 +764,6 @@ pub(crate) mod seq {
 
 #[cfg(feature = "owned")]
 pub(crate) mod owned {
-    use crate::std::boxed::Box;
-
     impl value_bag_serde1::lib::Serialize for crate::OwnedValueBag {
         fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
         where
@@ -775,12 +773,12 @@ pub(crate) mod owned {
         }
     }
 
-    pub(crate) type OwnedSerialize = Box<value_bag_serde1::buf::Owned>;
+    pub(crate) type OwnedSerialize = value_bag_serde1::buf::Owned;
 
     pub(crate) fn buffer(
         v: impl value_bag_serde1::lib::Serialize,
     ) -> Result<OwnedSerialize, value_bag_serde1::buf::Error> {
-        value_bag_serde1::buf::Owned::buffer(v).map(Box::new)
+        value_bag_serde1::buf::Owned::buffer(v)
     }
 }
 


### PR DESCRIPTION
The most recent `serde_buf` release's `Owned` is a single `Box<[u8]>`, so is small enough to store inline in an `OwnedValueBag` unconditionally.